### PR TITLE
feat: add onboarding landing page

### DIFF
--- a/api/billboard.js
+++ b/api/billboard.js
@@ -1,0 +1,91 @@
+// A representative slice of the Billboard Hot 100 / Artist 100. These names are
+// resolved against the Spotify catalogue at request time so the comparison
+// always uses live popularity, follower and genre data.
+const BILLBOARD_ARTISTS = [
+  'Taylor Swift',
+  'Drake',
+  'The Weeknd',
+  'Bad Bunny',
+  'Billie Eilish',
+  'Sabrina Carpenter',
+  'SZA',
+  'Morgan Wallen',
+  'Kendrick Lamar',
+  'Post Malone',
+  'Ariana Grande',
+  'Olivia Rodrigo',
+  'Travis Scott',
+  'Doja Cat',
+  'Ed Sheeran',
+  'Beyoncé',
+  'Dua Lipa',
+  'Chappell Roan',
+  'Zach Bryan',
+  'Future',
+  'Lana Del Rey',
+  'Bruno Mars',
+  'Tyla',
+  'Benson Boone',
+];
+
+async function lookupArtist(name, token) {
+  const url =
+    'https://api.spotify.com/v1/search?' +
+    new URLSearchParams({ q: name, type: 'artist', limit: '1' });
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) return null;
+
+  const data = await response.json();
+  const artist = data.artists?.items?.[0];
+  if (!artist) return null;
+
+  return {
+    name: artist.name,
+    popularity: artist.popularity ?? 0,
+    followers: artist.followers?.total ?? 0,
+    genres: artist.genres ?? [],
+    image: artist.images?.[artist.images.length - 1]?.url ?? null,
+  };
+}
+
+export default async function handler(req, res) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Missing access token' });
+
+  try {
+    const resolved = await Promise.all(
+      BILLBOARD_ARTISTS.map((name) => lookupArtist(name, token)),
+    );
+    const artists = resolved.filter(Boolean);
+
+    if (artists.length === 0) {
+      return res.status(502).json({ error: 'Could not resolve Billboard data' });
+    }
+
+    const averagePopularity = Math.round(
+      artists.reduce((sum, a) => sum + a.popularity, 0) / artists.length,
+    );
+    const averageFollowers = Math.round(
+      artists.reduce((sum, a) => sum + a.followers, 0) / artists.length,
+    );
+
+    const genreCounts = {};
+    for (const artist of artists) {
+      for (const genre of artist.genres) {
+        genreCounts[genre] = (genreCounts[genre] ?? 0) + 1;
+      }
+    }
+    const genres = Object.entries(genreCounts)
+      .map(([genre, count]) => ({ genre, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 12);
+
+    res.json({ artists, averagePopularity, averageFollowers, genres });
+  } catch (err) {
+    console.error('Billboard comparison error:', err.message);
+    res.status(500).json({ error: 'Failed to build Billboard comparison' });
+  }
+}

--- a/api/top-artists.js
+++ b/api/top-artists.js
@@ -3,7 +3,7 @@ export default async function handler(req, res) {
   if (!token) return res.status(401).json({ error: 'Missing access token' });
 
   try {
-    const response = await fetch('https://api.spotify.com/v1/me/top/artists?limit=20', {
+    const response = await fetch('https://api.spotify.com/v1/me/top/artists?limit=50', {
       headers: { Authorization: `Bearer ${token}` },
     });
     const data = await response.json();

--- a/api/top-songs.js
+++ b/api/top-songs.js
@@ -3,7 +3,7 @@ export default async function handler(req, res) {
   if (!token) return res.status(401).json({ error: 'Missing access token' });
 
   try {
-    const response = await fetch('https://api.spotify.com/v1/me/top/tracks?limit=20', {
+    const response = await fetch('https://api.spotify.com/v1/me/top/tracks?limit=50', {
       headers: { Authorization: `Bearer ${token}` },
     });
     const data = await response.json();

--- a/client/src/api/spotify.ts
+++ b/client/src/api/spotify.ts
@@ -1,4 +1,9 @@
-import type { SpotifyTrack } from '../types/spotify';
+import type {
+  SpotifyTrack,
+  SpotifyTopArtist,
+  RecentPlay,
+  BillboardData,
+} from '../types/spotify';
 
 export async function exchangeCodeForToken(code: string): Promise<string | null> {
   const res = await fetch(`/api/authenticate?code=${code}`);
@@ -16,28 +21,51 @@ export async function fetchTopTracks(token: string): Promise<SpotifyTrack[]> {
   return data.items ?? [];
 }
 
-export async function fetchRecentlyPlayed(token: string): Promise<Record<string, number>> {
-  const res = await fetch('/api/recently_played_song', {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) return {};
-  const data = await res.json();
-  const counts: Record<string, number> = {};
-  for (const item of data.items ?? []) {
-    const id = item.track.id;
-    counts[id] = (counts[id] ?? 0) + 1;
-  }
-  return counts;
-}
-
-export async function fetchGenreCounts(token: string): Promise<{ genre: string; count: number }[]> {
+export async function fetchTopArtists(token: string): Promise<SpotifyTopArtist[]> {
   const res = await fetch('/api/top-artists', {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) return [];
   const data = await res.json();
+  return data.items ?? [];
+}
+
+/** Raw recently-played history, including the `played_at` timestamp per play. */
+export async function fetchRecentPlays(token: string): Promise<RecentPlay[]> {
+  const res = await fetch('/api/recently_played_song', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.items ?? [];
+}
+
+/** Billboard chart benchmark data, resolved server-side against Spotify. */
+export async function fetchBillboard(token: string): Promise<BillboardData | null> {
+  const res = await fetch('/api/billboard', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+/** Counts how many times each track id appears in the recent-play history. */
+export function computePlayCounts(plays: RecentPlay[]): Record<string, number> {
   const counts: Record<string, number> = {};
-  for (const artist of data.items ?? []) {
+  for (const play of plays) {
+    const id = play.track?.id;
+    if (!id) continue;
+    counts[id] = (counts[id] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/** Tallies genres across the user's top artists, returning the eight largest. */
+export function computeGenreCounts(
+  artists: SpotifyTopArtist[],
+): { genre: string; count: number }[] {
+  const counts: Record<string, number> = {};
+  for (const artist of artists) {
     for (const genre of artist.genres ?? []) {
       counts[genre] = (counts[genre] ?? 0) + 1;
     }

--- a/client/src/components/LandingPage.tsx
+++ b/client/src/components/LandingPage.tsx
@@ -1,0 +1,135 @@
+const FEATURES = [
+  {
+    icon: '🎧',
+    title: 'Listening Stats',
+    desc: 'Your top tracks, artists and genres at a glance.',
+  },
+  {
+    icon: '🕒',
+    title: 'Listening Clock',
+    desc: 'A heatmap of when you listen across hours and days.',
+  },
+  {
+    icon: '📈',
+    title: 'Discovery Rate',
+    desc: 'See how often you explore new music versus replaying favourites.',
+  },
+  {
+    icon: '🔥',
+    title: 'Listening Marathons',
+    desc: 'Your longest uninterrupted listening sessions, ranked.',
+  },
+  {
+    icon: '💫',
+    title: 'Artist Obsessions',
+    desc: 'Phases where one artist took over — then faded out.',
+  },
+  {
+    icon: '🏆',
+    title: 'Billboard Comparison',
+    desc: 'Measure your taste against the Billboard chart artists.',
+  },
+];
+
+const STEPS = [
+  {
+    title: 'Connect your Spotify',
+    desc: 'Securely sign in with Spotify. We only request read access to your listening data.',
+  },
+  {
+    title: 'We analyse your history',
+    desc: 'Spoti-List crunches your top tracks, artists and recent plays into clear insights.',
+  },
+  {
+    title: 'Explore your dashboard',
+    desc: 'Dive into heatmaps, marathons, discovery trends and your Billboard score.',
+  },
+];
+
+export function LandingPage({ loginUrl }: { loginUrl: string }) {
+  return (
+    <div className="mx-auto max-w-5xl">
+      {/* Hero */}
+      <section className="flex flex-col items-center text-center">
+        <span className="mb-6 rounded-full border border-zinc-700 px-4 py-1 text-xs uppercase tracking-widest text-zinc-400">
+          Your Personal Spotify Analytics
+        </span>
+        <h2 className="max-w-2xl text-4xl font-bold leading-tight tracking-tight sm:text-5xl">
+          Understand your music taste like never before
+        </h2>
+        <p className="mt-4 max-w-xl text-base text-zinc-400">
+          Spoti-List turns your Spotify listening history into a personal
+          dashboard — discover your patterns, obsessions and how your taste
+          stacks up against the charts.
+        </p>
+        <a
+          href={loginUrl}
+          className="mt-8 rounded-full bg-green-500 px-8 py-3 text-sm font-semibold text-black transition-colors hover:bg-green-400"
+        >
+          Connect with Spotify
+        </a>
+        <p className="mt-3 text-xs text-zinc-500">
+          Free · No data stored · Read-only access
+        </p>
+      </section>
+
+      {/* Feature overview */}
+      <section className="mt-20">
+        <h3 className="mb-6 text-center text-sm font-medium uppercase tracking-widest text-zinc-400">
+          What you'll discover
+        </h3>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {FEATURES.map((feature) => (
+            <div
+              key={feature.title}
+              className="rounded-xl bg-zinc-800 p-5 transition-colors hover:bg-zinc-700/70"
+            >
+              <span className="text-2xl">{feature.icon}</span>
+              <h4 className="mt-3 text-base font-semibold text-white">
+                {feature.title}
+              </h4>
+              <p className="mt-1 text-sm text-zinc-400">{feature.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Onboarding steps */}
+      <section className="mt-20">
+        <h3 className="mb-6 text-center text-sm font-medium uppercase tracking-widest text-zinc-400">
+          How it works
+        </h3>
+        <div className="grid gap-4 md:grid-cols-3">
+          {STEPS.map((step, index) => (
+            <div key={step.title} className="rounded-xl bg-zinc-800 p-6">
+              <span className="flex h-9 w-9 items-center justify-center rounded-full bg-green-500 text-sm font-bold text-black">
+                {index + 1}
+              </span>
+              <h4 className="mt-4 text-base font-semibold text-white">
+                {step.title}
+              </h4>
+              <p className="mt-1 text-sm text-zinc-400">{step.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Closing call to action */}
+      <section className="mt-20 flex flex-col items-center rounded-2xl bg-zinc-800 px-6 py-12 text-center">
+        <h3 className="text-2xl font-bold tracking-tight">
+          Ready to see your sound?
+        </h3>
+        <p className="mt-2 max-w-md text-sm text-zinc-400">
+          Connect your account and your personalised dashboard will be ready in
+          seconds.
+        </p>
+        <a
+          href={loginUrl}
+          className="mt-6 rounded-full bg-green-500 px-8 py-3 text-sm font-semibold text-black transition-colors hover:bg-green-400"
+        >
+          Connect with Spotify
+        </a>
+      </section>
+    </div>
+  );
+}

--- a/client/src/hooks/useSpotifyAuth.ts
+++ b/client/src/hooks/useSpotifyAuth.ts
@@ -1,44 +1,99 @@
 import { useState, useEffect } from 'react';
-import type { SpotifyTrack } from '../types/spotify';
-import { exchangeCodeForToken, fetchTopTracks, fetchRecentlyPlayed, fetchGenreCounts } from '../api/spotify';
+import type {
+  SpotifyTrack,
+  SpotifyTopArtist,
+  RecentPlay,
+  BillboardData,
+} from '../types/spotify';
+import {
+  exchangeCodeForToken,
+  fetchTopTracks,
+  fetchTopArtists,
+  fetchRecentPlays,
+  fetchBillboard,
+  computePlayCounts,
+  computeGenreCounts,
+} from '../api/spotify';
 
-interface GenreEntry { genre: string; count: number }
+interface GenreEntry {
+  genre: string;
+  count: number;
+}
 
 interface SpotifyAuthState {
   isLoggedIn: boolean;
+  isLoading: boolean;
   topTracks: SpotifyTrack[];
+  topArtists: SpotifyTopArtist[];
+  recentPlays: RecentPlay[];
   playCounts: Record<string, number>;
   genreCounts: GenreEntry[];
-  isLoading: boolean;
+  billboard: BillboardData | null;
+  billboardLoading: boolean;
 }
 
 export function useSpotifyAuth(): SpotifyAuthState {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [topTracks, setTopTracks] = useState<SpotifyTrack[]>([]);
-  const [playCounts, setPlayCounts] = useState<Record<string, number>>({});
-  const [genreCounts, setGenreCounts] = useState<GenreEntry[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [topTracks, setTopTracks] = useState<SpotifyTrack[]>([]);
+  const [topArtists, setTopArtists] = useState<SpotifyTopArtist[]>([]);
+  const [recentPlays, setRecentPlays] = useState<RecentPlay[]>([]);
+  const [billboard, setBillboard] = useState<BillboardData | null>(null);
+  const [billboardLoading, setBillboardLoading] = useState(false);
 
   useEffect(() => {
     const code = new URLSearchParams(window.location.search).get('code');
     if (!code) return;
 
     setIsLoading(true);
+    setBillboardLoading(true);
+
     exchangeCodeForToken(code)
       .then((token) => {
-        if (!token) return;
+        if (!token) {
+          setIsLoading(false);
+          setBillboardLoading(false);
+          return;
+        }
         setIsLoggedIn(true);
-        return Promise.all([fetchTopTracks(token), fetchRecentlyPlayed(token), fetchGenreCounts(token)]);
+
+        // The Billboard comparison resolves dozens of catalogue lookups, so it
+        // loads independently and never blocks the rest of the dashboard.
+        fetchBillboard(token)
+          .then(setBillboard)
+          .catch(() => setBillboard(null))
+          .finally(() => setBillboardLoading(false));
+
+        return Promise.all([
+          fetchTopTracks(token),
+          fetchTopArtists(token),
+          fetchRecentPlays(token),
+        ])
+          .then(([tracks, artists, plays]) => {
+            setTopTracks(tracks);
+            setTopArtists(artists);
+            setRecentPlays(plays);
+          })
+          .finally(() => setIsLoading(false));
       })
-      .then((results) => {
-        if (!results) return;
-        const [tracks, counts, genres] = results;
-        setTopTracks(tracks);
-        setPlayCounts(counts);
-        setGenreCounts(genres);
-      })
-      .finally(() => setIsLoading(false));
+      .catch(() => {
+        setIsLoading(false);
+        setBillboardLoading(false);
+      });
   }, []);
 
-  return { isLoggedIn, topTracks, playCounts, genreCounts, isLoading };
+  const playCounts = computePlayCounts(recentPlays);
+  const genreCounts = computeGenreCounts(topArtists);
+
+  return {
+    isLoggedIn,
+    isLoading,
+    topTracks,
+    topArtists,
+    recentPlays,
+    playCounts,
+    genreCounts,
+    billboard,
+    billboardLoading,
+  };
 }

--- a/client/src/types/spotify.ts
+++ b/client/src/types/spotify.ts
@@ -17,3 +17,35 @@ export interface SpotifyTrack {
   album: SpotifyAlbum;
   external_urls: { spotify: string };
 }
+
+/** A fully-detailed artist as returned by /me/top/artists. */
+export interface SpotifyTopArtist extends SpotifyArtist {
+  genres: string[];
+  popularity: number;
+  followers: { total: number };
+  images: { url: string; width: number; height: number }[];
+  external_urls: { spotify: string };
+}
+
+/** A single entry from /me/player/recently-played. */
+export interface RecentPlay {
+  played_at: string;
+  track: SpotifyTrack;
+}
+
+/** A Billboard chart artist resolved against the Spotify catalogue. */
+export interface BillboardArtist {
+  name: string;
+  popularity: number;
+  followers: number;
+  genres: string[];
+  image: string | null;
+}
+
+/** Aggregated Billboard benchmark data returned by /api/billboard. */
+export interface BillboardData {
+  artists: BillboardArtist[];
+  averagePopularity: number;
+  averageFollowers: number;
+  genres: { genre: string; count: number }[];
+}

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,42 +1,135 @@
 const express = require('express');
-const axios = require('axios');
 const router = express.Router();
 
-router.get('/authenticate', async (req, res) => {
-  const code = req.query.code;
-  if (!code) return res.status(400).json({ error: 'Missing code parameter' });
+// Representative slice of the Billboard Hot 100 / Artist 100, resolved against
+// the live Spotify catalogue. Kept in sync with /api/billboard.js.
+const BILLBOARD_ARTISTS = [
+  'Taylor Swift', 'Drake', 'The Weeknd', 'Bad Bunny', 'Billie Eilish',
+  'Sabrina Carpenter', 'SZA', 'Morgan Wallen', 'Kendrick Lamar', 'Post Malone',
+  'Ariana Grande', 'Olivia Rodrigo', 'Travis Scott', 'Doja Cat', 'Ed Sheeran',
+  'Beyoncé', 'Dua Lipa', 'Chappell Roan', 'Zach Bryan', 'Future',
+  'Lana Del Rey', 'Bruno Mars', 'Tyla', 'Benson Boone',
+];
+
+function getToken(req) {
+  return req.headers.authorization?.split(' ')[1];
+}
+
+/** Proxies a Spotify Web API GET request through to the client. */
+async function proxySpotify(req, res, url, label) {
+  const token = getToken(req);
+  if (!token) return res.status(401).json({ error: 'Missing access token' });
 
   try {
-    const response = await axios.post(
-      'https://accounts.spotify.com/api/token',
-      new URLSearchParams({
-        grant_type: 'authorization_code',
-        code,
-        redirect_uri: process.env.REDIRECT_URI,
-        client_id: process.env.SPOTIFY_CLIENT_ID,
-        client_secret: process.env.SPOTIFY_CLIENT_SECRET,
-      }),
-      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
-    );
-    res.json(response.data);
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await response.json();
+    if (!response.ok) return res.status(response.status).json(data);
+    res.json(data);
   } catch (err) {
-    console.error('Token exchange error:', err.response?.data ?? err.message);
+    console.error(`${label} error:`, err.message);
+    res.status(500).json({ error: `Failed to fetch ${label}` });
+  }
+}
+
+router.get('/authenticate', async (req, res) => {
+  const { code } = req.query;
+  if (!code) return res.status(400).json({ error: 'Missing code parameter' });
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: process.env.REDIRECT_URI,
+    client_id: process.env.SPOTIFY_CLIENT_ID,
+    client_secret: process.env.SPOTIFY_CLIENT_SECRET,
+  });
+
+  try {
+    const response = await fetch('https://accounts.spotify.com/api/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    const data = await response.json();
+    if (!response.ok) return res.status(response.status).json(data);
+    res.json(data);
+  } catch (err) {
+    console.error('Token exchange error:', err.message);
     res.status(500).json({ error: 'Failed to exchange code for token' });
   }
 });
 
-router.get('/top-songs', async (req, res) => {
-  const token = req.headers.authorization?.split(' ')[1];
+router.get('/top-songs', (req, res) =>
+  proxySpotify(req, res, 'https://api.spotify.com/v1/me/top/tracks?limit=50', 'top tracks'),
+);
+
+router.get('/top-artists', (req, res) =>
+  proxySpotify(req, res, 'https://api.spotify.com/v1/me/top/artists?limit=50', 'top artists'),
+);
+
+router.get('/recently_played_song', (req, res) =>
+  proxySpotify(
+    req,
+    res,
+    'https://api.spotify.com/v1/me/player/recently-played?limit=50',
+    'recently played songs',
+  ),
+);
+
+router.get('/billboard', async (req, res) => {
+  const token = getToken(req);
   if (!token) return res.status(401).json({ error: 'Missing access token' });
 
   try {
-    const response = await axios.get('https://api.spotify.com/v1/me/top/tracks?limit=20', {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    res.json(response.data);
+    const resolved = await Promise.all(
+      BILLBOARD_ARTISTS.map(async (name) => {
+        const url =
+          'https://api.spotify.com/v1/search?' +
+          new URLSearchParams({ q: name, type: 'artist', limit: '1' });
+        const response = await fetch(url, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!response.ok) return null;
+        const data = await response.json();
+        const artist = data.artists?.items?.[0];
+        if (!artist) return null;
+        return {
+          name: artist.name,
+          popularity: artist.popularity ?? 0,
+          followers: artist.followers?.total ?? 0,
+          genres: artist.genres ?? [],
+          image: artist.images?.[artist.images.length - 1]?.url ?? null,
+        };
+      }),
+    );
+    const artists = resolved.filter(Boolean);
+    if (artists.length === 0) {
+      return res.status(502).json({ error: 'Could not resolve Billboard data' });
+    }
+
+    const averagePopularity = Math.round(
+      artists.reduce((sum, a) => sum + a.popularity, 0) / artists.length,
+    );
+    const averageFollowers = Math.round(
+      artists.reduce((sum, a) => sum + a.followers, 0) / artists.length,
+    );
+
+    const genreCounts = {};
+    for (const artist of artists) {
+      for (const genre of artist.genres) {
+        genreCounts[genre] = (genreCounts[genre] ?? 0) + 1;
+      }
+    }
+    const genres = Object.entries(genreCounts)
+      .map(([genre, count]) => ({ genre, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 12);
+
+    res.json({ artists, averagePopularity, averageFollowers, genres });
   } catch (err) {
-    console.error('Top tracks error:', err.response?.data ?? err.message);
-    res.status(500).json({ error: 'Failed to fetch top tracks' });
+    console.error('Billboard comparison error:', err.message);
+    res.status(500).json({ error: 'Failed to build Billboard comparison' });
   }
 });
 


### PR DESCRIPTION
- Add LandingPage component with hero, feature overview and onboarding steps (issue #3)
- Add /api/billboard endpoint resolving Billboard chart artists against the Spotify catalogue
- Extend Spotify API client with fetchTopArtists, fetchRecentPlays and fetchBillboard
- Expand useSpotifyAuth hook to load top artists, recent plays and Billboard data
- Add SpotifyTopArtist, RecentPlay and Billboard types
- Mirror all routes in the Express dev server for local parity
- Raise top tracks/artists fetch limit from 20 to 50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Billboard artist lookup with aggregated statistics including popularity, followers, and top genres
  * Recently played tracks endpoint
  * New landing page with product features and onboarding guidance
  * Increased top artists data retrieval limit (now fetches up to 50 items)

* **Refactor**
  * API layer restructured for improved modularity and performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d4n1elliu/Spoti-list/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->