### PR TITLE
feat: add listening clock heatmap

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,9 +6,11 @@ import { TrackList } from './components/TrackList';
 import { PopularityBarChart } from './components/PopularityBarChart';
 import { RecentPlayCount } from './components/RecentPlayCount';
 import { GenrePieChart } from './components/GenrePieChart';
+import { ListeningHeatmap } from './components/ListeningHeatmap';
 
 export default function App() {
-  const { isLoggedIn, topTracks, playCounts, genreCounts, isLoading } = useSpotifyAuth();
+  const { isLoggedIn, topTracks, recentPlays, playCounts, genreCounts, isLoading } =
+    useSpotifyAuth();
 
   if (isLoading) {
     return (
@@ -48,6 +50,8 @@ export default function App() {
             </h2>
             <RecentPlayCount tracks={topTracks} playCounts={playCounts} />
           </div>
+
+          <ListeningHeatmap plays={recentPlays} />
         </div>
       )}
     </div>

--- a/client/src/components/ListeningHeatmap.tsx
+++ b/client/src/components/ListeningHeatmap.tsx
@@ -1,0 +1,161 @@
+import type { RecentPlay } from '../types/spotify';
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const HOUR_LABELS = [0, 3, 6, 9, 12, 15, 18, 21];
+
+function formatHour(hour: number): string {
+  if (hour === 0) return '12am';
+  if (hour === 12) return '12pm';
+  return hour < 12 ? `${hour}am` : `${hour - 12}pm`;
+}
+
+export function ListeningHeatmap({ plays }: { plays: RecentPlay[] }) {
+  // grid[day][hour] = number of plays that started in that slot.
+  const grid: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
+  for (const play of plays) {
+    const date = new Date(play.played_at);
+    if (Number.isNaN(date.getTime())) continue;
+    grid[date.getDay()][date.getHours()] += 1;
+  }
+
+  const flat = grid.flat();
+  const max = Math.max(1, ...flat);
+  const total = flat.reduce((sum, n) => sum + n, 0);
+
+  // Split the day into mood windows to surface focus vs. wind-down patterns.
+  let focus = 0; // 09:00–17:59
+  let windDown = 0; // 18:00–23:59
+  let lateNight = 0; // 00:00–08:59
+  let peakHour = 0;
+  let peakDay = 0;
+  let peakCount = 0;
+  for (let day = 0; day < 7; day++) {
+    for (let hour = 0; hour < 24; hour++) {
+      const count = grid[day][hour];
+      if (hour >= 9 && hour < 18) focus += count;
+      else if (hour >= 18) windDown += count;
+      else lateNight += count;
+      if (count > peakCount) {
+        peakCount = count;
+        peakHour = hour;
+        peakDay = day;
+      }
+    }
+  }
+
+  if (total === 0) {
+    return (
+      <section className="rounded-xl bg-zinc-800 p-6">
+        <h3 className="mb-4 text-sm font-medium uppercase tracking-widest text-zinc-400">
+          Listening Clock
+        </h3>
+        <p className="text-center text-sm text-zinc-500">
+          No recent listening history to map yet.
+        </p>
+      </section>
+    );
+  }
+
+  const pct = (value: number) => Math.round((value / total) * 100);
+
+  return (
+    <section className="rounded-xl bg-zinc-800 p-6">
+      <h3 className="mb-1 text-sm font-medium uppercase tracking-widest text-zinc-400">
+        Listening Clock
+      </h3>
+      <p className="mb-5 text-xs text-zinc-500">
+        When you listen, across hours and days · last {total} plays
+      </p>
+
+      <div className="overflow-x-auto">
+        <div className="min-w-[520px]">
+          {/* Hour axis */}
+          <div
+            className="grid text-[10px] text-zinc-500"
+            style={{ gridTemplateColumns: '34px repeat(24, 1fr)' }}
+          >
+            <span />
+            {Array.from({ length: 24 }, (_, hour) => (
+              <span key={hour} className="text-center">
+                {HOUR_LABELS.includes(hour) ? formatHour(hour) : ''}
+              </span>
+            ))}
+          </div>
+
+          {/* Day rows */}
+          {grid.map((row, day) => (
+            <div
+              key={day}
+              className="grid items-center"
+              style={{ gridTemplateColumns: '34px repeat(24, 1fr)' }}
+            >
+              <span className="pr-2 text-right text-[11px] text-zinc-500">
+                {DAYS[day]}
+              </span>
+              {row.map((count, hour) => {
+                const intensity = count === 0 ? 0 : 0.15 + 0.85 * (count / max);
+                return (
+                  <div
+                    key={hour}
+                    title={`${DAYS[day]} ${formatHour(hour)} — ${count} play${count === 1 ? '' : 's'}`}
+                    className="m-px aspect-square rounded-[3px]"
+                    style={{
+                      backgroundColor:
+                        count === 0
+                          ? '#27272a'
+                          : `rgba(29, 185, 84, ${intensity})`,
+                    }}
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="mt-4 flex items-center gap-2 text-[11px] text-zinc-500">
+        <span>Less</span>
+        {[0, 0.3, 0.55, 0.8, 1].map((step) => (
+          <span
+            key={step}
+            className="h-3 w-3 rounded-[3px]"
+            style={{
+              backgroundColor:
+                step === 0
+                  ? '#27272a'
+                  : `rgba(29, 185, 84, ${0.15 + 0.85 * step})`,
+            }}
+          />
+        ))}
+        <span>More</span>
+      </div>
+
+      {/* Pattern summary */}
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        <div className="rounded-lg bg-zinc-900 p-3">
+          <p className="text-xs text-zinc-500">Peak slot</p>
+          <p className="mt-1 text-sm font-semibold text-green-400">
+            {DAYS[peakDay]} at {formatHour(peakHour)}
+          </p>
+        </div>
+        <div className="rounded-lg bg-zinc-900 p-3">
+          <p className="text-xs text-zinc-500">Work focus (9am–6pm)</p>
+          <p className="mt-1 text-sm font-semibold text-white">{pct(focus)}%</p>
+        </div>
+        <div className="rounded-lg bg-zinc-900 p-3">
+          <p className="text-xs text-zinc-500">Wind down (6pm–12am)</p>
+          <p className="mt-1 text-sm font-semibold text-white">
+            {pct(windDown)}%
+          </p>
+        </div>
+      </div>
+      {lateNight > 0 && (
+        <p className="mt-3 text-xs text-zinc-500">
+          {pct(lateNight)}% of your listening happens late night or early
+          morning (12am–9am).
+        </p>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
- Implement a listening heatmap component that renders a 7 x 24 hours/day grid from recent plays
- Render heatmap into the dashboard