### PR TITLE
feat: implemented longest listening marathons graph

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { PopularityBarChart } from './components/PopularityBarChart';
 import { RecentPlayCount } from './components/RecentPlayCount';
 import { GenrePieChart } from './components/GenrePieChart';
 import { ListeningHeatmap } from './components/ListeningHeatmap';
+import { ListeningMarathons } from './components/ListeningMarathons';
 
 export default function App() {
   const { isLoggedIn, topTracks, recentPlays, playCounts, genreCounts, isLoading } =
@@ -52,6 +53,8 @@ export default function App() {
           </div>
 
           <ListeningHeatmap plays={recentPlays} />
+
+          <ListeningMarathons plays={recentPlays} />
         </div>
       )}
     </div>

--- a/client/src/components/ListeningMarathons.tsx
+++ b/client/src/components/ListeningMarathons.tsx
@@ -1,0 +1,181 @@
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import type { RecentPlay } from '../types/spotify';
+
+// Plays within this gap of the previous track ending still count as the same
+// uninterrupted session.
+const GAP_TOLERANCE_MS = 5 * 60 * 1000;
+
+interface Marathon {
+  plays: RecentPlay[];
+  start: number;
+  end: number;
+  totalMs: number;
+}
+
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.round(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return hours === 0 ? `${minutes}m` : `${hours}h ${minutes}m`;
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/** Groups recent plays into continuous sessions and returns the longest five. */
+function buildMarathons(plays: RecentPlay[]): Marathon[] {
+  const sorted = plays
+    .filter((p) => !Number.isNaN(new Date(p.played_at).getTime()))
+    .sort(
+      (a, b) =>
+        new Date(a.played_at).getTime() - new Date(b.played_at).getTime(),
+    );
+
+  const sessions: Marathon[] = [];
+  let current: Marathon | null = null;
+  let prevStart = 0;
+  let prevDuration = 0;
+
+  for (const play of sorted) {
+    const start = new Date(play.played_at).getTime();
+    const duration = play.track?.duration_ms ?? 0;
+    const continues =
+      current !== null && start - prevStart <= prevDuration + GAP_TOLERANCE_MS;
+
+    if (continues && current) {
+      current.plays.push(play);
+      current.totalMs += duration;
+      current.end = start + duration;
+    } else {
+      current = {
+        plays: [play],
+        start,
+        end: start + duration,
+        totalMs: duration,
+      };
+      sessions.push(current);
+    }
+    prevStart = start;
+    prevDuration = duration;
+  }
+
+  return sessions
+    .filter((session) => session.plays.length >= 2)
+    .sort((a, b) => b.totalMs - a.totalMs)
+    .slice(0, 5);
+}
+
+export function ListeningMarathons({ plays }: { plays: RecentPlay[] }) {
+  const marathons = buildMarathons(plays);
+
+  if (marathons.length === 0) {
+    return (
+      <section className="rounded-xl bg-zinc-800 p-6">
+        <h3 className="mb-4 text-sm font-medium uppercase tracking-widest text-zinc-400">
+          Listening Marathons
+        </h3>
+        <p className="text-center text-sm text-zinc-500">
+          No back-to-back listening sessions found in your recent history yet.
+        </p>
+      </section>
+    );
+  }
+
+  const chartData = marathons.map((session, index) => ({
+    name: `#${index + 1} · ${formatDate(session.start)}`,
+    minutes: Math.round(session.totalMs / 60000),
+  }));
+
+  return (
+    <section className="rounded-xl bg-zinc-800 p-6">
+      <h3 className="mb-1 text-sm font-medium uppercase tracking-widest text-zinc-400">
+        Listening Marathons
+      </h3>
+      <p className="mb-5 text-xs text-zinc-500">
+        Your longest uninterrupted listening sessions, ranked by total time
+      </p>
+
+      <ResponsiveContainer width="100%" height={Math.max(150, chartData.length * 52)}>
+        <BarChart
+          data={chartData}
+          layout="vertical"
+          margin={{ top: 0, right: 16, left: 0, bottom: 0 }}
+        >
+          <XAxis
+            type="number"
+            tick={{ fill: '#71717a', fontSize: 11 }}
+            tickFormatter={(value: number) => `${value}m`}
+          />
+          <YAxis
+            type="category"
+            dataKey="name"
+            width={130}
+            tick={{ fill: '#a1a1aa', fontSize: 11 }}
+          />
+          <Tooltip
+            contentStyle={{ background: '#18181b', border: 'none', borderRadius: 8 }}
+            labelStyle={{ color: '#fff', fontSize: 12 }}
+            itemStyle={{ color: '#1db954' }}
+            cursor={{ fill: 'rgba(255,255,255,0.04)' }}
+            formatter={(value: number) => [formatDuration(value * 60000), 'Listening time']}
+          />
+          <Bar dataKey="minutes" radius={[0, 4, 4, 0]}>
+            {chartData.map((_, index) => (
+              <Cell key={index} fill={index === 0 ? '#1db954' : '#3f3f46'} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      <div className="mt-5 space-y-3">
+        {marathons.map((session, index) => {
+          const trackNames = session.plays.map((p) => p.track?.name ?? 'Unknown');
+          const preview = trackNames.slice(0, 3).join(' · ');
+          const remaining = trackNames.length - 3;
+          return (
+            <div
+              key={session.start}
+              className="flex items-center gap-4 rounded-lg bg-zinc-900 p-4"
+            >
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-800 text-sm font-bold text-green-400">
+                {index + 1}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-white">
+                  {formatDate(session.start)}
+                </p>
+                <p className="text-xs text-zinc-500">
+                  {formatTime(session.start)} – {formatTime(session.end)}
+                </p>
+                <p className="mt-1 truncate text-xs text-zinc-400">
+                  {preview}
+                  {remaining > 0 && ` +${remaining} more`}
+                </p>
+              </div>
+              <div className="shrink-0 text-right">
+                <p className="text-sm font-semibold text-green-400">
+                  {formatDuration(session.totalMs)}
+                </p>
+                <p className="text-xs text-zinc-500">
+                  {session.plays.length} tracks
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
- Added listeningMarathons component which groups recent plays into continous sessions.
- Rank top 5 sessions through total listening time in a horizontal bar chart
- List each session's date, time range, track count and track preview
- Render marathon section in dashboard
- Tracks plays within the last 5 minutes of the previous track ending as the same session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Listening Marathons" section to the dashboard
  * Displays your top 5 uninterrupted listening sessions ranked by total duration
  * Shows session details including date/time range, track preview, total duration, and track count
  * Visualizes sessions with an interactive bar chart for easy comparison

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d4n1elliu/Spoti-list/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->