### PR TITLE
Add Billboard Hot 100 comparison to user's top Spotify artists

### DIFF
--- a/api/billboard.js
+++ b/api/billboard.js
@@ -80,6 +80,7 @@ async function lookupArtist(name, token) {
     followers: artist.followers?.total ?? 0,
     genres: artist.genres ?? [],
     image: artist.images[artist.images.length - 1].url,
+    url: artist.external_urls?.spotify ?? `https://open.spotify.com/artist/${artist.id}`,
   };
 }
 

--- a/api/billboard.js
+++ b/api/billboard.js
@@ -71,12 +71,15 @@ async function lookupArtist(name, token) {
   const artist = data.artists?.items?.[0];
   if (!artist) return null;
 
+  // Discard results with no image — they're almost always wrong Spotify matches
+  if (!artist.images?.length) return null;
+
   return {
     name: artist.name,
     popularity: artist.popularity ?? 0,
     followers: artist.followers?.total ?? 0,
     genres: artist.genres ?? [],
-    image: artist.images?.[artist.images.length - 1]?.url ?? null,
+    image: artist.images[artist.images.length - 1].url,
   };
 }
 

--- a/api/billboard.js
+++ b/api/billboard.js
@@ -5,44 +5,56 @@ function primaryArtist(rawArtist) {
     .trim();
 }
 
+function htmlDecode(str) {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
 async function fetchHot100Artists() {
-  const res = await fetch('https://www.billboard.com/charts/hot-100/', {
-    headers: {
-      'User-Agent':
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-      'Accept-Language': 'en-US,en;q=0.9',
-    },
-  });
-  if (!res.ok) throw new Error(`Billboard responded ${res.status}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
 
-  const html = await res.text();
-  const m = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/);
-  if (!m) throw new Error('__NEXT_DATA__ not found on Billboard page');
+  try {
+    const res = await fetch('https://www.billboard.com/charts/hot-100/', {
+      signal: controller.signal,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept-Language': 'en-US,en;q=0.9',
+        Accept: 'text/html',
+      },
+    });
+    if (!res.ok) throw new Error(`Billboard responded ${res.status}`);
 
-  const { props } = JSON.parse(m[1]);
-  const entries =
-    props?.pageProps?.data?.chartData?.entries ??
-    props?.pageProps?.chartData?.entries ??
-    [];
-  if (!entries.length) throw new Error('No chart entries found in __NEXT_DATA__');
+    const html = await res.text();
 
-  const seen = new Set();
-  const names = [];
-  for (const e of entries) {
-    const raw =
-      e?.chartItem?.artistName ??
-      e?.artist ??
-      e?.artists?.[0]?.name ??
-      '';
-    if (!raw) continue;
-    const primary = primaryArtist(raw);
-    const key = primary.toLowerCase();
-    if (primary && !seen.has(key)) {
-      seen.add(key);
-      names.push(primary);
+    // Split page into per-row blocks then extract the artist link from each
+    const rows = html.split('o-chart-results-list-row-container');
+    const seen = new Set();
+    const names = [];
+
+    for (const row of rows) {
+      const m = row.match(/<span[^>]*c-label[^>]*>[\s\S]*?<a[^>]*>([^<]+)<\/a>/);
+      if (!m) continue;
+      const raw = htmlDecode(m[1].trim());
+      const primary = primaryArtist(raw);
+      const key = primary.toLowerCase();
+      if (primary && !seen.has(key)) {
+        seen.add(key);
+        names.push(primary);
+      }
     }
+
+    if (!names.length) throw new Error('No artists parsed from Billboard page');
+    return names;
+  } finally {
+    clearTimeout(timeout);
   }
-  return names;
 }
 
 async function lookupArtist(name, token) {

--- a/client/src/components/insights/BillboardComparison.tsx
+++ b/client/src/components/insights/BillboardComparison.tsx
@@ -122,13 +122,26 @@ export function BillboardComparison({ billboard, billboardLoading, topArtists, t
                 {/* User side */}
                 <div className="flex items-center gap-2 pr-4">
                   <span className="w-5 shrink-0 text-xs text-zinc-600">{row.rank}</span>
-                  <ArtistAvatar
-                    src={row.userArtist?.images?.[row.userArtist.images.length - 1]?.url}
-                    alt={row.userArtist?.name ?? ''}
-                  />
-                  <span className="min-w-0 flex-1 truncate text-sm text-white">
+                  <a
+                    href={row.userArtist?.external_urls?.spotify}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0"
+                    tabIndex={row.userArtist ? 0 : -1}
+                  >
+                    <ArtistAvatar
+                      src={row.userArtist?.images?.[row.userArtist.images.length - 1]?.url}
+                      alt={row.userArtist?.name ?? ''}
+                    />
+                  </a>
+                  <a
+                    href={row.userArtist?.external_urls?.spotify}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="min-w-0 flex-1 truncate text-sm text-white hover:underline"
+                  >
                     {row.userArtist?.name ?? <span className="text-zinc-600">—</span>}
-                  </span>
+                  </a>
                   <span className="shrink-0 text-xs text-zinc-400">
                     {row.userArtist?.popularity ?? ''}
                   </span>
@@ -160,13 +173,26 @@ export function BillboardComparison({ billboard, billboardLoading, topArtists, t
                   <span className="shrink-0 text-xs text-zinc-400">
                     {row.billboardArtist?.popularity ?? ''}
                   </span>
-                  <span className="min-w-0 flex-1 truncate text-right text-sm text-white">
+                  <a
+                    href={row.billboardArtist?.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="min-w-0 flex-1 truncate text-right text-sm text-white hover:underline"
+                  >
                     {row.billboardArtist?.name ?? <span className="text-zinc-600">—</span>}
-                  </span>
-                  <ArtistAvatar
-                    src={row.billboardArtist?.image}
-                    alt={row.billboardArtist?.name ?? ''}
-                  />
+                  </a>
+                  <a
+                    href={row.billboardArtist?.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0"
+                    tabIndex={row.billboardArtist ? 0 : -1}
+                  >
+                    <ArtistAvatar
+                      src={row.billboardArtist?.image}
+                      alt={row.billboardArtist?.name ?? ''}
+                    />
+                  </a>
                   <span className="w-5 shrink-0 text-right text-xs text-zinc-600">{row.rank}</span>
                 </div>
               </div>

--- a/client/src/components/insights/BillboardComparison.tsx
+++ b/client/src/components/insights/BillboardComparison.tsx
@@ -86,7 +86,7 @@ export function BillboardComparison({ billboard, billboardLoading, topArtists, t
           </p>
           <div />
           <p className="text-right text-xs font-medium uppercase tracking-widest text-zinc-400">
-            Billboard Hot 100
+            US Billboard Hot 100
           </p>
         </div>
 

--- a/client/src/types/spotify.ts
+++ b/client/src/types/spotify.ts
@@ -40,6 +40,7 @@ export interface BillboardArtist {
   followers: number;
   genres: string[];
   image: string | null;
+  url: string;
 }
 
 /** Aggregated Billboard benchmark data returned by /api/billboard. */

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -154,6 +154,7 @@ router.get('/billboard', async (req, res) => {
           followers: artist.followers?.total ?? 0,
           genres: artist.genres ?? [],
           image: artist.images[artist.images.length - 1].url,
+          url: artist.external_urls?.spotify ?? `https://open.spotify.com/artist/${artist.id}`,
         };
       }),
     );

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -145,12 +145,15 @@ router.get('/billboard', async (req, res) => {
         const data = await response.json();
         const artist = data.artists?.items?.[0];
         if (!artist) return null;
+        // Discard results with no image — they're almost always wrong Spotify matches
+        if (!artist.images?.length) return null;
+
         return {
           name: artist.name,
           popularity: artist.popularity ?? 0,
           followers: artist.followers?.total ?? 0,
           genres: artist.genres ?? [],
-          image: artist.images?.[artist.images.length - 1]?.url ?? null,
+          image: artist.images[artist.images.length - 1].url,
         };
       }),
     );

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -8,44 +8,56 @@ function primaryArtist(rawArtist) {
     .trim();
 }
 
+function htmlDecode(str) {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
 async function fetchHot100Artists() {
-  const res = await fetch('https://www.billboard.com/charts/hot-100/', {
-    headers: {
-      'User-Agent':
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-      'Accept-Language': 'en-US,en;q=0.9',
-    },
-  });
-  if (!res.ok) throw new Error(`Billboard responded ${res.status}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
 
-  const html = await res.text();
-  const m = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/);
-  if (!m) throw new Error('__NEXT_DATA__ not found on Billboard page');
+  try {
+    const res = await fetch('https://www.billboard.com/charts/hot-100/', {
+      signal: controller.signal,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept-Language': 'en-US,en;q=0.9',
+        Accept: 'text/html',
+      },
+    });
+    if (!res.ok) throw new Error(`Billboard responded ${res.status}`);
 
-  const { props } = JSON.parse(m[1]);
-  const entries =
-    props?.pageProps?.data?.chartData?.entries ??
-    props?.pageProps?.chartData?.entries ??
-    [];
-  if (!entries.length) throw new Error('No chart entries found in __NEXT_DATA__');
+    const html = await res.text();
 
-  const seen = new Set();
-  const names = [];
-  for (const e of entries) {
-    const raw =
-      e?.chartItem?.artistName ??
-      e?.artist ??
-      e?.artists?.[0]?.name ??
-      '';
-    if (!raw) continue;
-    const primary = primaryArtist(raw);
-    const key = primary.toLowerCase();
-    if (primary && !seen.has(key)) {
-      seen.add(key);
-      names.push(primary);
+    // Split page into per-row blocks then extract the artist link from each
+    const rows = html.split('o-chart-results-list-row-container');
+    const seen = new Set();
+    const names = [];
+
+    for (const row of rows) {
+      const m = row.match(/<span[^>]*c-label[^>]*>[\s\S]*?<a[^>]*>([^<]+)<\/a>/);
+      if (!m) continue;
+      const raw = htmlDecode(m[1].trim());
+      const primary = primaryArtist(raw);
+      const key = primary.toLowerCase();
+      if (primary && !seen.has(key)) {
+        seen.add(key);
+        names.push(primary);
+      }
     }
+
+    if (!names.length) throw new Error('No artists parsed from Billboard page');
+    return names;
+  } finally {
+    clearTimeout(timeout);
   }
-  return names;
 }
 
 function getToken(req) {


### PR DESCRIPTION
## Summary
Side-by-side comparison of the user's top Spotify artists against the
current Billboard Hot 100, with overlap highlighting and aggregate stats.

## Changes
- Refactored Billboard fetch off brittle `__NEXT_DATA__` scraping
- Added `htmlDecode()` so artist names render correctly
- Filter out Billboard entries missing artist images
- Clarified US Billboard column header