### PR TITLE
fix: improve mobile responsive layout across dashboard

### DIFF
--- a/client/src/components/dashboard/Dashboard.tsx
+++ b/client/src/components/dashboard/Dashboard.tsx
@@ -39,14 +39,14 @@ export function Dashboard({
 }: DashboardProps) {
   return (
     <div className="mx-auto max-w-6xl space-y-8">
-      <div className="grid gap-6 md:grid-cols-3">
+      <div className="grid gap-4 md:gap-6 md:grid-cols-3">
         {topTracks[0] && <TopTrackCard track={topTracks[0]} />}
         <div className="relative md:col-span-1">
-          <div className="hide-scrollbar h-[420px] overflow-y-auto md:absolute md:inset-0 md:h-auto">
+          <div className="hide-scrollbar h-72 overflow-y-auto sm:h-[420px] md:absolute md:inset-0 md:h-auto">
             <TrackList tracks={topTracks.slice(1, 50)} />
           </div>
         </div>
-        <div className="space-y-6">
+        <div className="space-y-4 md:space-y-6">
           <PopularityBarChart tracks={topTracks.slice(0, 50)} />
           <GenrePieChart genres={genreCounts} />
         </div>

--- a/client/src/components/dashboard/GenrePieChart.tsx
+++ b/client/src/components/dashboard/GenrePieChart.tsx
@@ -19,13 +19,13 @@ export function GenrePieChart({ genres }: { genres: { genre: string; count: numb
       <h3 className="mb-4 text-sm font-medium uppercase tracking-widest text-zinc-400">
         Top Genres
       </h3>
-      <ResponsiveContainer width="100%" height={320}>
+      <ResponsiveContainer width="100%" height={280}>
         <PieChart style={{ outline: 'none' }}>
           <Pie
             data={data}
             cx="50%"
             cy="45%"
-            outerRadius={100}
+            outerRadius={85}
             dataKey="value"
             // Show percentage inside each slice
             label={({ percent }) => `${((percent ?? 0) * 100).toFixed(0)}%`}

--- a/client/src/components/dashboard/PopularityBarChart.tsx
+++ b/client/src/components/dashboard/PopularityBarChart.tsx
@@ -20,7 +20,7 @@ export function PopularityBarChart({ tracks }: { tracks: SpotifyTrack[] }) {
       <h3 className="mb-4 text-sm font-medium uppercase tracking-widest text-zinc-400">
         Popularity
       </h3>
-      <ResponsiveContainer width="100%" height={300}>
+      <ResponsiveContainer width="100%" height={220}>
         <BarChart data={data} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
           {/* Track names are hidden as there are too many to show on a small chart */}
           <XAxis dataKey="name" hide />

--- a/client/src/components/dashboard/TopTrackCard.tsx
+++ b/client/src/components/dashboard/TopTrackCard.tsx
@@ -3,6 +3,9 @@ import { formatTrackLength } from '../../lib';
 
 // Large card for the user's #1 most listened track and directly links to Spotify
 export function TopTrackCard({ track }: { track: SpotifyTrack }) {
+  const artists = track.artists.map((a) => a.name).join(', ');
+  const duration = formatTrackLength(track.duration_ms);
+
   return (
     <a
       href={track.external_urls.spotify}
@@ -10,21 +13,33 @@ export function TopTrackCard({ track }: { track: SpotifyTrack }) {
       rel="noreferrer"
       className="block rounded-xl bg-zinc-800 p-4 shadow transition-colors hover:bg-zinc-700"
     >
-      <img
-        src={track.album.images[0]?.url}
-        alt={track.album.name}
-        className="mb-3 w-full rounded-lg object-cover"
-      />
-      <p className="text-xs font-medium uppercase tracking-widest text-green-400">
-        #1 Top Track
-      </p>
-      <h2 className="mt-1 text-lg font-semibold text-white">{track.name}</h2>
-      <p className="mt-0.5 text-sm text-zinc-400">
-        {track.artists.map((a) => a.name).join(', ')}
-      </p>
-      <p className="mt-2 text-xs text-zinc-500">
-        Duration: {formatTrackLength(track.duration_ms)}
-      </p>
+      {/* Mobile (< sm): compact horizontal layout so the image doesn't dominate the screen */}
+      <div className="flex items-center gap-4 sm:hidden">
+        <img
+          src={track.album.images[0]?.url}
+          alt={track.album.name}
+          className="h-20 w-20 shrink-0 rounded-lg object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium uppercase tracking-widest text-green-400">#1 Top Track</p>
+          <h2 className="mt-0.5 text-base font-semibold text-white">{track.name}</h2>
+          <p className="mt-0.5 truncate text-xs text-zinc-400">{artists}</p>
+          <p className="mt-1 text-xs text-zinc-500">Duration: {duration}</p>
+        </div>
+      </div>
+
+      {/* sm+: original vertical full-image layout */}
+      <div className="hidden sm:block">
+        <img
+          src={track.album.images[0]?.url}
+          alt={track.album.name}
+          className="mb-3 w-full rounded-lg object-cover"
+        />
+        <p className="text-xs font-medium uppercase tracking-widest text-green-400">#1 Top Track</p>
+        <h2 className="mt-1 text-lg font-semibold text-white">{track.name}</h2>
+        <p className="mt-0.5 text-sm text-zinc-400">{artists}</p>
+        <p className="mt-2 text-xs text-zinc-500">Duration: {duration}</p>
+      </div>
     </a>
   );
 }

--- a/client/src/components/insights/ListeningHeatmap.tsx
+++ b/client/src/components/insights/ListeningHeatmap.tsx
@@ -38,7 +38,7 @@ export function ListeningHeatmap({ plays }: { plays: RecentPlay[] }) {
       </p>
 
       <div className="overflow-x-auto">
-        <div className="min-w-[440px]">
+        <div className="min-w-[340px]">
           {/* Hour labels along the top */}
           <div
             className="grid text-[10px] text-zinc-500"
@@ -99,7 +99,7 @@ export function ListeningHeatmap({ plays }: { plays: RecentPlay[] }) {
       </div>
 
       {/* Summary stats below the grid */}
-      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+      <div className="mt-5 grid grid-cols-3 gap-2 sm:gap-3">
         <div className="rounded-lg bg-zinc-900 p-3">
           <p className="text-xs text-zinc-500">Peak slot</p>
           <p className="mt-1 text-sm font-semibold text-green-400">
@@ -107,14 +107,18 @@ export function ListeningHeatmap({ plays }: { plays: RecentPlay[] }) {
           </p>
         </div>
         <div className="rounded-lg bg-zinc-900 p-3">
-          <p className="text-xs text-zinc-500">Work focus (9am–6pm)</p>
+          <p className="text-xs text-zinc-500">
+            <span className="hidden sm:inline">Work focus (9am–6pm)</span>
+            <span className="sm:hidden">Work hrs</span>
+          </p>
           <p className="mt-1 text-sm font-semibold text-white">{pct(focus)}%</p>
         </div>
         <div className="rounded-lg bg-zinc-900 p-3">
-          <p className="text-xs text-zinc-500">Wind down (6pm–12am)</p>
-          <p className="mt-1 text-sm font-semibold text-white">
-            {pct(windDown)}%
+          <p className="text-xs text-zinc-500">
+            <span className="hidden sm:inline">Wind down (6pm–12am)</span>
+            <span className="sm:hidden">Evening</span>
           </p>
+          <p className="mt-1 text-sm font-semibold text-white">{pct(windDown)}%</p>
         </div>
       </div>
       {lateNight > 0 && (


### PR DESCRIPTION
- TopTrackCard: compact horizontal layout on mobile (80px thumbnail) instead of full width album art that dominated the first screen
- Dashboard: reduce TrackList height on mobile (420px to 288px)
- PopularityBarChart: reduce chart height (300px to 220px)
- GenrePieChart: reduce chart height and pie radius to fit mobile
- ListeningHeatmap: shrink min width of scrollable grid (440px to 340px), always show 3 column stats grid with shorter labels on mobile