### PR TITLE
feat: add taste match view when scanning another user's QR (#16)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,12 @@ import { useState } from 'react';
 import { useSpotifyAuth } from './hooks';
 import { buildSpotifyAuthUrl } from './api';
 import { LandingPage } from './components/landing';
-import { Dashboard, ShareModal, QRScannerModal } from './components/dashboard';
+import { Dashboard, ShareModal, QRScannerModal, TasteMatchModal } from './components/dashboard';
+
+interface TasteMatchState {
+  encodedPayload: string;
+  theirSpotifyId: string;
+}
 
 // Root of the app which decides whether to show the landing page or the dashboard
 export default function App() {
@@ -17,10 +22,17 @@ export default function App() {
     billboard,
     billboardLoading,
     spotifyId,
+    displayName,
+    token: _token,
   } = useSpotifyAuth();
 
   const [shareOpen, setShareOpen] = useState(false);
   const [scanOpen, setScanOpen] = useState(false);
+  const [tasteMatch, setTasteMatch] = useState<TasteMatchState | null>(null);
+
+  function handleTasteMatch(encodedPayload: string, theirSpotifyId: string) {
+    setTasteMatch({ encodedPayload, theirSpotifyId });
+  }
 
   // Show a spinner while the initial Spotify data is loading
   if (isLoading) {
@@ -77,11 +89,36 @@ export default function App() {
       </header>
 
       {/* QR scanner modal */}
-      {scanOpen && <QRScannerModal onClose={() => setScanOpen(false)} />}
+      {scanOpen && (
+        <QRScannerModal
+          onClose={() => setScanOpen(false)}
+          onTasteMatch={handleTasteMatch}
+        />
+      )}
 
-      {/* Modal that shows the QR code and copyable profile link */}
+      {/* Share modal — includes taste profile encoded into the QR */}
       {shareOpen && spotifyId && (
-        <ShareModal spotifyId={spotifyId} onClose={() => setShareOpen(false)} />
+        <ShareModal
+          spotifyId={spotifyId}
+          displayName={displayName ?? spotifyId}
+          topArtists={topArtists}
+          topTracks={topTracks}
+          genreCounts={genreCounts}
+          onClose={() => setShareOpen(false)}
+        />
+      )}
+
+      {/* Taste match modal — shown after scanning a friend's QR */}
+      {tasteMatch && (
+        <TasteMatchModal
+          encodedPayload={tasteMatch.encodedPayload}
+          theirSpotifyId={tasteMatch.theirSpotifyId}
+          myDisplayName={displayName ?? 'You'}
+          myTopArtists={topArtists}
+          myTopTracks={topTracks}
+          myGenreCounts={genreCounts}
+          onClose={() => setTasteMatch(null)}
+        />
       )}
 
       <Dashboard

--- a/client/src/components/dashboard/QRScannerModal.tsx
+++ b/client/src/components/dashboard/QRScannerModal.tsx
@@ -3,6 +3,7 @@ import jsQR from 'jsqr';
 
 interface QRScannerModalProps {
   onClose: () => void;
+  onTasteMatch?: (encodedPayload: string, theirSpotifyId: string) => void;
 }
 
 // BarcodeDetector is not yet in the TypeScript lib, so we declare it minimally
@@ -20,8 +21,24 @@ declare global {
 }
 
 const SOLERI_ORIGIN = 'https://soleri.app';
+const SOLERI_USER_PATH = SOLERI_ORIGIN + '/u/';
 
-export function QRScannerModal({ onClose }: QRScannerModalProps) {
+interface ParsedSoleriUrl {
+  spotifyId: string;
+  tastePayload: string | null;
+}
+
+function parseSoleriUrl(url: string): ParsedSoleriUrl | null {
+  if (!url.startsWith(SOLERI_USER_PATH)) return null;
+  const rest = url.slice(SOLERI_USER_PATH.length);
+  const qIndex = rest.indexOf('?');
+  const spotifyId = qIndex >= 0 ? rest.slice(0, qIndex) : rest;
+  if (!spotifyId) return null;
+  const params = new URLSearchParams(qIndex >= 0 ? rest.slice(qIndex + 1) : '');
+  return { spotifyId, tastePayload: params.get('p') };
+}
+
+export function QRScannerModal({ onClose, onTasteMatch }: QRScannerModalProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -61,17 +78,15 @@ export function QRScannerModal({ onClose }: QRScannerModalProps) {
 
     let result: string | null = null;
 
-    // Try native BarcodeDetector first (Chrome, Edge, Android WebView)
     if (detectorRef.current) {
       try {
         const codes = await detectorRef.current.detect(canvas);
         if (codes.length > 0) result = codes[0].rawValue;
       } catch {
-        // detector failed on this frame — fall through to jsQR
+        // fall through to jsQR
       }
     }
 
-    // jsQR fallback (Firefox, Safari, etc.)
     if (!result) {
       const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
       const code = jsQR(imageData.data, canvas.width, canvas.height, {
@@ -90,7 +105,6 @@ export function QRScannerModal({ onClose }: QRScannerModalProps) {
   }, [stopCamera]);
 
   useEffect(() => {
-    // Initialise BarcodeDetector once
     if (window.BarcodeDetector) {
       detectorRef.current = new window.BarcodeDetector({ formats: ['qr_code'] });
     }
@@ -118,11 +132,49 @@ export function QRScannerModal({ onClose }: QRScannerModalProps) {
     return stopCamera;
   }, [scanFrame, stopCamera]);
 
-  const isSoleriUrl = scannedUrl?.startsWith(SOLERI_ORIGIN + '/u/');
+  const parsed = scannedUrl ? parseSoleriUrl(scannedUrl) : null;
+  const isSoleriUrl = !!parsed;
+  const hasTastePayload = !!(parsed?.tastePayload && onTasteMatch);
+
+  function handleTasteMatch() {
+    if (parsed?.tastePayload && onTasteMatch) {
+      stopCamera();
+      onTasteMatch(parsed.tastePayload, parsed.spotifyId);
+      onClose();
+    }
+  }
 
   function openUrl() {
-    if (scannedUrl) window.open(scannedUrl, '_blank', 'noopener,noreferrer');
+    if (scannedUrl) {
+      // Open the clean profile URL (without the long taste payload)
+      const cleanUrl = parsed
+        ? `${SOLERI_USER_PATH}${parsed.spotifyId}`
+        : scannedUrl;
+      window.open(cleanUrl, '_blank', 'noopener,noreferrer');
+    }
     handleClose();
+  }
+
+  async function restartCamera() {
+    scanningRef.current = true;
+    setStatus('requesting');
+    setScannedUrl(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: 'environment' } },
+        audio: false,
+      });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+        setStatus('scanning');
+        scanFrame();
+      }
+    } catch {
+      setErrorMsg('Camera access denied.');
+      setStatus('error');
+    }
   }
 
   return (
@@ -149,17 +201,10 @@ export function QRScannerModal({ onClose }: QRScannerModalProps) {
         {/* Camera viewport */}
         {status !== 'found' && (
           <div className="relative mx-5 mb-4 overflow-hidden rounded-xl bg-zinc-900" style={{ aspectRatio: '1' }}>
-            <video
-              ref={videoRef}
-              className="h-full w-full object-cover"
-              muted
-              playsInline
-            />
-            {/* Scanning overlay */}
+            <video ref={videoRef} className="h-full w-full object-cover" muted playsInline />
             {status === 'scanning' && (
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                 <div className="relative h-48 w-48">
-                  {/* Corner brackets */}
                   <span className="absolute left-0 top-0 h-8 w-8 border-l-2 border-t-2 border-green-400 rounded-tl-md" />
                   <span className="absolute right-0 top-0 h-8 w-8 border-r-2 border-t-2 border-green-400 rounded-tr-md" />
                   <span className="absolute left-0 bottom-0 h-8 w-8 border-l-2 border-b-2 border-green-400 rounded-bl-md" />
@@ -172,7 +217,6 @@ export function QRScannerModal({ onClose }: QRScannerModalProps) {
                 <p className="text-sm text-zinc-400">Requesting camera…</p>
               </div>
             )}
-            {/* Hidden canvas used for frame analysis */}
             <canvas ref={canvasRef} className="hidden" />
           </div>
         )}
@@ -194,11 +238,33 @@ export function QRScannerModal({ onClose }: QRScannerModalProps) {
               <span className="text-sm text-green-300 font-medium">QR code detected!</span>
             </div>
 
-            <div className="rounded-lg bg-zinc-700 px-3 py-2.5">
-              <p className="truncate text-sm text-zinc-300">{scannedUrl}</p>
-            </div>
+            {isSoleriUrl && (
+              <div className="rounded-lg bg-zinc-700 px-3 py-2.5">
+                <p className="truncate text-sm text-zinc-300">
+                  {SOLERI_USER_PATH}{parsed!.spotifyId}
+                </p>
+              </div>
+            )}
 
-            {isSoleriUrl ? (
+            {hasTastePayload ? (
+              <>
+                <button
+                  onClick={handleTasteMatch}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-green-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-green-500"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                  </svg>
+                  Compare Tastes
+                </button>
+                <button
+                  onClick={openUrl}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-zinc-600 py-2 text-sm text-zinc-400 transition-colors hover:border-zinc-500 hover:text-white"
+                >
+                  View profile
+                </button>
+              </>
+            ) : isSoleriUrl ? (
               <button
                 onClick={openUrl}
                 className="flex w-full items-center justify-center gap-2 rounded-lg bg-green-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-green-500"
@@ -210,40 +276,21 @@ export function QRScannerModal({ onClose }: QRScannerModalProps) {
                 View Soleri profile
               </button>
             ) : (
-              <button
-                onClick={openUrl}
-                className="flex w-full items-center justify-center gap-2 rounded-lg bg-zinc-700 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-600"
-              >
-                Open link
-              </button>
+              <>
+                <div className="rounded-lg bg-zinc-700 px-3 py-2.5">
+                  <p className="truncate text-sm text-zinc-300">{scannedUrl}</p>
+                </div>
+                <button
+                  onClick={openUrl}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-zinc-700 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-600"
+                >
+                  Open link
+                </button>
+              </>
             )}
 
             <button
-              onClick={() => {
-                scanningRef.current = true;
-                setStatus('requesting');
-                setScannedUrl(null);
-                // Re-start camera
-                async function restart() {
-                  try {
-                    const stream = await navigator.mediaDevices.getUserMedia({
-                      video: { facingMode: { ideal: 'environment' } },
-                      audio: false,
-                    });
-                    streamRef.current = stream;
-                    if (videoRef.current) {
-                      videoRef.current.srcObject = stream;
-                      await videoRef.current.play();
-                      setStatus('scanning');
-                      scanFrame();
-                    }
-                  } catch {
-                    setErrorMsg('Camera access denied.');
-                    setStatus('error');
-                  }
-                }
-                restart();
-              }}
+              onClick={restartCamera}
               className="w-full rounded-lg border border-zinc-600 py-2 text-sm text-zinc-400 transition-colors hover:border-zinc-500 hover:text-white"
             >
               Scan again

--- a/client/src/components/dashboard/ShareModal.tsx
+++ b/client/src/components/dashboard/ShareModal.tsx
@@ -1,35 +1,49 @@
 import { useState, useEffect } from 'react';
 import QRCode from 'qrcode';
+import type { SpotifyTopArtist, SpotifyTrack } from '../../types';
+import { encodeTasteProfile } from '../../lib';
 
 interface ShareModalProps {
-  spotifyId: string; // e.g. "smedjan"
+  spotifyId: string;
+  displayName: string;
+  topArtists: SpotifyTopArtist[];
+  topTracks: SpotifyTrack[];
+  genreCounts: { genre: string; count: number }[];
   onClose: () => void;
 }
 
-export function ShareModal({ spotifyId, onClose }: ShareModalProps) {
-  // Starts empty and filled in once the QR library finishes generating the image
+export function ShareModal({
+  spotifyId,
+  displayName,
+  topArtists,
+  topTracks,
+  genreCounts,
+  onClose,
+}: ShareModalProps) {
   const [qrDataUrl, setQrDataUrl] = useState('');
   const [copied, setCopied] = useState(false);
 
   const profileUrl = `https://soleri.app/u/${spotifyId}`;
 
-  // Generate the QR as a base64 PNG; white on dark so it fits the modal
+  // QR URL embeds the taste payload so scanners can show a comparison view
+  const tasteEncoded = encodeTasteProfile(displayName, topArtists, topTracks, genreCounts);
+  const qrUrl = `${profileUrl}?p=${tasteEncoded}`;
+
   useEffect(() => {
-    QRCode.toDataURL(profileUrl, {
+    QRCode.toDataURL(qrUrl, {
       width: 200,
       margin: 2,
       color: { dark: '#ffffff', light: '#27272a' },
+      errorCorrectionLevel: 'L',
     }).then(setQrDataUrl);
-  }, [profileUrl]);
+  }, [qrUrl]);
 
-  // Copy to clipboard and then briefly show a checkmark
   function copyUrl() {
     navigator.clipboard.writeText(profileUrl);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
 
-  // Create a hidden <a> pointing at the base64 PNG and click it to trigger a download
   function downloadQr() {
     const a = document.createElement('a');
     a.href = qrDataUrl;
@@ -38,12 +52,10 @@ export function ShareModal({ spotifyId, onClose }: ShareModalProps) {
   }
 
   return (
-    // Clicking on the dark backdrop closes the modal
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
       onClick={onClose}
     >
-      {/* Stop clicks inside the card from bubbling up to the backdrop */}
       <div
         className="w-full max-w-xs rounded-2xl bg-zinc-800 p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
@@ -59,7 +71,6 @@ export function ShareModal({ spotifyId, onClose }: ShareModalProps) {
           </button>
         </div>
 
-        {/* Pulsing placeholder while the QR is generating */}
         <div className="mb-5 flex justify-center">
           {qrDataUrl ? (
             <img
@@ -74,7 +85,10 @@ export function ShareModal({ spotifyId, onClose }: ShareModalProps) {
           )}
         </div>
 
-        {/* In URL row, the icon swaps to a tick after copying */}
+        <p className="mb-3 text-center text-xs text-zinc-500">
+          Friends who scan this will see your taste match
+        </p>
+
         <div className="mb-3 flex items-center gap-2 rounded-lg bg-zinc-700 px-3 py-2.5">
           <span className="flex-1 truncate text-sm text-zinc-300">{profileUrl}</span>
           <button
@@ -95,7 +109,6 @@ export function ShareModal({ spotifyId, onClose }: ShareModalProps) {
           </button>
         </div>
 
-        {/* Disabling the QR code until it is ready as you can't download a blank image */}
         <button
           onClick={downloadQr}
           disabled={!qrDataUrl}

--- a/client/src/components/dashboard/TasteMatchModal.tsx
+++ b/client/src/components/dashboard/TasteMatchModal.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useState } from 'react';
+import type { SpotifyTopArtist, SpotifyTrack } from '../../types';
+import {
+  decodeTasteProfile,
+  computeTasteMatch,
+  compatibilityLabel,
+  type TasteMatchResult,
+} from '../../lib';
+
+interface TasteMatchModalProps {
+  encodedPayload: string;
+  theirSpotifyId: string;
+  myDisplayName: string;
+  myTopArtists: SpotifyTopArtist[];
+  myTopTracks: SpotifyTrack[];
+  myGenreCounts: { genre: string; count: number }[];
+  onClose: () => void;
+}
+
+function InitialAvatar({ name, size = 'md' }: { name: string; size?: 'sm' | 'md' }) {
+  const initial = name.trim().charAt(0).toUpperCase() || '?';
+  const cls = size === 'sm' ? 'h-10 w-10 text-base' : 'h-12 w-12 text-lg';
+  return (
+    <div className={`${cls} flex items-center justify-center rounded-full bg-zinc-700 font-semibold text-zinc-200`}>
+      {initial}
+    </div>
+  );
+}
+
+function ScoreRing({ score }: { score: number }) {
+  const label = compatibilityLabel(score);
+  const color =
+    score >= 80
+      ? 'text-green-400'
+      : score >= 60
+        ? 'text-emerald-400'
+        : score >= 40
+          ? 'text-yellow-400'
+          : score >= 20
+            ? 'text-orange-400'
+            : 'text-zinc-400';
+
+  return (
+    <div className="flex flex-col items-center gap-1 py-4">
+      <span className={`text-6xl font-bold tabular-nums ${color}`}>{score}</span>
+      <span className="text-xs font-medium uppercase tracking-widest text-zinc-500">
+        compatibility
+      </span>
+      <span className={`text-sm font-semibold ${color}`}>{label}</span>
+    </div>
+  );
+}
+
+export function TasteMatchModal({
+  encodedPayload,
+  theirSpotifyId: _theirSpotifyId,
+  myDisplayName,
+  myTopArtists,
+  myTopTracks,
+  myGenreCounts,
+  onClose,
+}: TasteMatchModalProps) {
+  const [result, setResult] = useState<TasteMatchResult | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const payload = decodeTasteProfile(encodedPayload);
+    if (!payload) {
+      setError(true);
+      return;
+    }
+    setResult(computeTasteMatch(payload, myTopArtists, myTopTracks, myGenreCounts));
+  }, [encodedPayload, myTopArtists, myTopTracks, myGenreCounts]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl bg-zinc-800 shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-2">
+          <span className="font-semibold text-white">Taste Match</span>
+          <button
+            onClick={onClose}
+            className="flex h-7 w-7 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-700 hover:text-white"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {error ? (
+          <div className="px-5 pb-5 pt-3 text-center text-sm text-zinc-400">
+            Couldn't read taste data from this QR code.
+          </div>
+        ) : !result ? (
+          <div className="px-5 pb-5 pt-3 text-center text-sm text-zinc-400">Computing…</div>
+        ) : (
+          <div className="px-5 pb-6 space-y-5">
+            {/* Both users */}
+            <div className="flex items-center justify-between gap-3 pt-1">
+              <div className="flex flex-1 flex-col items-center gap-1.5">
+                <InitialAvatar name={myDisplayName} />
+                <span className="max-w-[80px] truncate text-center text-xs text-zinc-300">
+                  {myDisplayName}
+                </span>
+              </div>
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-700">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-zinc-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M18 3a1 1 0 00-1.196-.98l-10 2A1 1 0 006 5v9.114A4.369 4.369 0 005 14c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V7.82l8-1.6v5.894A4.37 4.37 0 0015 12c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V3z" />
+                </svg>
+              </div>
+              <div className="flex flex-1 flex-col items-center gap-1.5">
+                <InitialAvatar name={result.themName} />
+                <span className="max-w-[80px] truncate text-center text-xs text-zinc-300">
+                  {result.themName}
+                </span>
+              </div>
+            </div>
+
+            {/* Score */}
+            <div className="rounded-xl bg-zinc-900 px-4">
+              <ScoreRing score={result.compatibilityScore} />
+            </div>
+
+            {/* Shared artists */}
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                Shared Artists{result.sharedArtists.length > 0 ? ` · ${result.sharedArtists.length}` : ''}
+              </p>
+              {result.sharedArtists.length === 0 ? (
+                <p className="text-sm text-zinc-500">No shared artists yet</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {result.sharedArtists.map((artist) => (
+                    <a
+                      key={artist.id}
+                      href={artist.external_urls.spotify}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-2 rounded-full bg-zinc-700 pl-1 pr-3 py-1 transition-colors hover:bg-zinc-600"
+                    >
+                      {artist.images[0]?.url ? (
+                        <img
+                          src={artist.images[0].url}
+                          alt={artist.name}
+                          className="h-6 w-6 rounded-full object-cover"
+                        />
+                      ) : (
+                        <div className="h-6 w-6 rounded-full bg-zinc-600" />
+                      )}
+                      <span className="text-xs text-zinc-200">{artist.name}</span>
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Genre overlap */}
+            <div>
+              <div className="mb-1.5 flex items-center justify-between">
+                <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                  Genre Overlap
+                </p>
+                <span className="text-xs font-semibold text-zinc-300">
+                  {result.genreOverlapPct}%
+                </span>
+              </div>
+              <div className="mb-2 h-1.5 w-full overflow-hidden rounded-full bg-zinc-700">
+                <div
+                  className="h-full rounded-full bg-green-500 transition-all duration-700"
+                  style={{ width: `${result.genreOverlapPct}%` }}
+                />
+              </div>
+              {result.sharedGenres.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {result.sharedGenres.map((g) => (
+                    <span
+                      key={g}
+                      className="rounded-full bg-zinc-700 px-2 py-0.5 text-xs capitalize text-zinc-300"
+                    >
+                      {g}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Shared top track */}
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                Top Shared Track
+              </p>
+              {!result.sharedTopTrack ? (
+                <p className="text-sm text-zinc-500">No tracks in common yet</p>
+              ) : (
+                <SharedTrackCard track={result.sharedTopTrack} />
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SharedTrackCard({ track }: { track: SpotifyTrack }) {
+  const albumImg = track.album.images[0]?.url;
+  const artistName = track.artists.map((a) => a.name).join(', ');
+  return (
+    <a
+      href={track.external_urls.spotify}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-3 rounded-xl bg-zinc-700 p-3 transition-colors hover:bg-zinc-600"
+    >
+      {albumImg ? (
+        <img src={albumImg} alt={track.album.name} className="h-12 w-12 rounded-lg object-cover" />
+      ) : (
+        <div className="h-12 w-12 rounded-lg bg-zinc-600" />
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-white">{track.name}</p>
+        <p className="truncate text-xs text-zinc-400">{artistName}</p>
+      </div>
+      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 shrink-0 text-zinc-500" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+        <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+      </svg>
+    </a>
+  );
+}

--- a/client/src/components/dashboard/index.ts
+++ b/client/src/components/dashboard/index.ts
@@ -4,5 +4,6 @@ export * from './PopularityBarChart';
 export * from './RecentPlayCount';
 export * from './QRScannerModal';
 export * from './ShareModal';
+export * from './TasteMatchModal';
 export * from './TopTrackCard';
 export * from './TrackList';

--- a/client/src/hooks/useSpotifyAuth.ts
+++ b/client/src/hooks/useSpotifyAuth.ts
@@ -32,6 +32,8 @@ interface SpotifyAuthState {
   billboard: BillboardData | null;
   billboardLoading: boolean;
   spotifyId: string | null;
+  displayName: string | null;
+  token: string | null;
 }
 
 export function useSpotifyAuth(): SpotifyAuthState {
@@ -44,6 +46,8 @@ export function useSpotifyAuth(): SpotifyAuthState {
   const [billboardLoading, setBillboardLoading] = useState(false);
   // Null on load; Share button stays hidden until this comes back
   const [spotifyId, setSpotifyId] = useState<string | null>(null);
+  const [displayName, setDisplayName] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
 
   useEffect(() => {
     // Spotify redirects back here with ?code=... after the user logs in
@@ -61,6 +65,7 @@ export function useSpotifyAuth(): SpotifyAuthState {
           return;
         }
         setIsLoggedIn(true);
+        setToken(token);
 
         // Billboard takes longer (lots of lookups), so it loads separately
         // and never blocks the rest of the dashboard from appearing
@@ -71,7 +76,10 @@ export function useSpotifyAuth(): SpotifyAuthState {
 
         // Run separately so it doesn't hold up the main dashboard fetch
         fetchUserProfile(token).then((profile) => {
-          if (profile) setSpotifyId(profile.id);
+          if (profile) {
+            setSpotifyId(profile.id);
+            setDisplayName(profile.display_name);
+          }
         });
 
         // Fetch the main dashboard data all at once
@@ -108,5 +116,7 @@ export function useSpotifyAuth(): SpotifyAuthState {
     billboard,
     billboardLoading,
     spotifyId,
+    displayName,
+    token,
   };
 }

--- a/client/src/lib/index.ts
+++ b/client/src/lib/index.ts
@@ -5,4 +5,5 @@ export * from './heatmap';
 export * from './marathons';
 export * from './obsession';
 export * from './stats';
+export * from './tasteProfile';
 export * from './theme';

--- a/client/src/lib/tasteProfile.ts
+++ b/client/src/lib/tasteProfile.ts
@@ -1,0 +1,100 @@
+import type { SpotifyTopArtist, SpotifyTrack } from '../types';
+
+// Compact taste payload encoded into the QR URL
+export interface TastePayload {
+  n: string;    // display name (max 20 chars)
+  a: string[];  // top 10 artist IDs
+  g: string[];  // top 5 genre strings
+  t: string[];  // top 5 track IDs
+}
+
+export interface TasteMatchResult {
+  themName: string;
+  sharedArtists: SpotifyTopArtist[];
+  sharedGenres: string[];
+  genreOverlapPct: number;
+  compatibilityScore: number;
+  sharedTopTrack: SpotifyTrack | null;
+}
+
+// UTF-8 safe base64url encode
+function toBase64Url(str: string): string {
+  return btoa(unescape(encodeURIComponent(str)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+// UTF-8 safe base64url decode
+function fromBase64Url(str: string): string {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = padded.length % 4;
+  const padded2 = pad ? padded + '='.repeat(4 - pad) : padded;
+  return decodeURIComponent(escape(atob(padded2)));
+}
+
+export function encodeTasteProfile(
+  displayName: string,
+  topArtists: SpotifyTopArtist[],
+  topTracks: SpotifyTrack[],
+  genreCounts: { genre: string; count: number }[],
+): string {
+  const payload: TastePayload = {
+    n: displayName.slice(0, 20),
+    a: topArtists.slice(0, 10).map((a) => a.id),
+    g: genreCounts.slice(0, 5).map((g) => g.genre),
+    t: topTracks.slice(0, 5).map((t) => t.id),
+  };
+  return toBase64Url(JSON.stringify(payload));
+}
+
+export function decodeTasteProfile(encoded: string): TastePayload | null {
+  try {
+    return JSON.parse(fromBase64Url(encoded)) as TastePayload;
+  } catch {
+    return null;
+  }
+}
+
+export function computeTasteMatch(
+  them: TastePayload,
+  myTopArtists: SpotifyTopArtist[],
+  myTopTracks: SpotifyTrack[],
+  myGenreCounts: { genre: string; count: number }[],
+): TasteMatchResult {
+  const theirArtistIds = new Set(them.a);
+  const theirGenres = new Set(them.g);
+  const theirTrackIds = new Set(them.t);
+
+  const sharedArtists = myTopArtists.filter((a) => theirArtistIds.has(a.id));
+
+  const myGenreSet = new Set(myGenreCounts.map((g) => g.genre));
+  const sharedGenres = [...myGenreSet].filter((g) => theirGenres.has(g));
+  const allGenres = new Set([...myGenreSet, ...theirGenres]);
+  const genreOverlapPct =
+    allGenres.size > 0 ? Math.round((sharedGenres.length / allGenres.size) * 100) : 0;
+
+  // 50 pts from artists (5+ shared = max), 50 pts from genre overlap
+  const artistScore = Math.min(sharedArtists.length * 10, 50);
+  const genreScore = Math.round(genreOverlapPct / 2);
+  const compatibilityScore = artistScore + genreScore;
+
+  const sharedTopTrack = myTopTracks.find((t) => theirTrackIds.has(t.id)) ?? null;
+
+  return {
+    themName: them.n,
+    sharedArtists: sharedArtists.slice(0, 5),
+    sharedGenres: sharedGenres.slice(0, 6),
+    genreOverlapPct,
+    compatibilityScore,
+    sharedTopTrack,
+  };
+}
+
+export function compatibilityLabel(score: number): string {
+  if (score >= 80) return 'Music Soulmates';
+  if (score >= 60) return 'Great Match';
+  if (score >= 40) return 'Good Vibes';
+  if (score >= 20) return 'Some Overlap';
+  return 'Different Worlds';
+}


### PR DESCRIPTION
- Encodes a compact taste payload into the QR URL so scanning a friend's QR code opens a comparison view showing shared artists, genre overlap %, compatibility score and the top shared track