### PR TITLE
fix: restore SPA rewrite and client-side Spotify auth URL

### DIFF
--- a/src/api/spotify.ts
+++ b/src/api/spotify.ts
@@ -60,5 +60,15 @@ export async function fetchUserProfile(
 }
 
 export function buildSpotifyAuthUrl(): string {
-  return '/api/auth/login';
+  const clientId = import.meta.env.VITE_SPOTIFY_CLIENT_ID as string;
+  const redirectUri = import.meta.env.VITE_REDIRECT_URI as string;
+  return (
+    'https://accounts.spotify.com/authorize?' +
+    new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      scope: 'user-read-email user-top-read user-read-recently-played',
+    })
+  );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,6 @@
   "buildCommand": "npm install && npm run build",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/((?!api/).*)", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
vercel.json: replace unsupported negative lookahead regex with plain /(.*) — Vercel processes api/ functions before rewrites so the API routes are unaffected. The old pattern silently failed, causing 404s on any sub-path (e.g. /u/:id).

src/api/spotify.ts: revert buildSpotifyAuthUrl() to build the URL client-side using VITE_SPOTIFY_CLIENT_ID / VITE_REDIRECT_URI. The server-side /api/auth/login approach required runtime env vars that weren't set, breaking the OAuth flow and causing empty dashboard data.