### PR TITLE
fix(api): add .js extensions to relative imports for node16 moduleResolution

### DIFF
--- a/api/billboard.ts
+++ b/api/billboard.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getToken, unauthorized, serverError } from './_lib/http';
-import { fetchHot100Artists, lookupArtist } from './_lib/billboard';
+import { getToken, unauthorized, serverError } from './_lib/http.js';
+import { fetchHot100Artists, lookupArtist } from './_lib/billboard.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const token = getToken(req);

--- a/api/spotify/recently-played.ts
+++ b/api/spotify/recently-played.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getToken, unauthorized, serverError } from '../_lib/http';
-import { spotifyFetch } from '../_lib/spotify';
+import { getToken, unauthorized, serverError } from '../_lib/http.js';
+import { spotifyFetch } from '../_lib/spotify.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const token = getToken(req);

--- a/api/spotify/top-artists.ts
+++ b/api/spotify/top-artists.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getToken, unauthorized, serverError } from '../_lib/http';
-import { spotifyFetch } from '../_lib/spotify';
+import { getToken, unauthorized, serverError } from '../_lib/http.js';
+import { spotifyFetch } from '../_lib/spotify.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const token = getToken(req);

--- a/api/spotify/top-tracks.ts
+++ b/api/spotify/top-tracks.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getToken, unauthorized, serverError } from '../_lib/http';
-import { spotifyFetch } from '../_lib/spotify';
+import { getToken, unauthorized, serverError } from '../_lib/http.js';
+import { spotifyFetch } from '../_lib/spotify.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const token = getToken(req);


### PR DESCRIPTION
Vercel compiles api/ functions with --moduleResolution node16 which requires explicit file extensions on all relative ESM imports.