### PR TITLE
fix(qr-scanner): open Spotify profile instead of soleri.app/u/ on View profile

### DIFF
--- a/src/components/dashboard/QRScannerModal.tsx
+++ b/src/components/dashboard/QRScannerModal.tsx
@@ -46,10 +46,10 @@ export function QRScannerModal({ onClose, onTasteMatch }: QRScannerModalProps) {
   }
 
   function openUrl() {
-    if (scannedUrl) {
-      const cleanUrl = parsed ? `${SOLERI_USER_PATH}${parsed.spotifyId}` : scannedUrl;
-      window.open(cleanUrl, '_blank', 'noopener,noreferrer');
-    }
+    const target = parsed
+      ? `https://open.spotify.com/user/${parsed.spotifyId}`
+      : scannedUrl;
+    if (target) window.open(target, '_blank', 'noopener,noreferrer');
     onClose();
   }
 


### PR DESCRIPTION
- Redirects to https://open.spotify.com/user/:id which always resolves, rather than the soleri.app/u/:id path which 404s.