### PR TITLE
feat(frontend): unify Core Features section with showcase bento design

### DIFF
--- a/src/components/landing/LandingCards.tsx
+++ b/src/components/landing/LandingCards.tsx
@@ -1,19 +1,28 @@
 import { motion, type Variants } from 'framer-motion';
 import type { Feature, Step } from './LandingData';
 
-export function FeatureCard({ feature, variants }: { feature: Feature; variants: Variants }) {
+export function FeatureCard({ feature, index, variants }: { feature: Feature; index: number; variants: Variants }) {
   return (
     <motion.div
       variants={variants}
-      whileHover={{ y: -6, transition: { duration: 0.2 } }}
-      className="group flex flex-col rounded-2xl bg-zinc-900 p-8 ring-1 ring-zinc-800 transition-colors hover:ring-zinc-700 hover:bg-zinc-900/90"
+      whileHover={{ y: -4 }}
+      className="flex flex-col justify-between rounded-3xl border border-zinc-800/80 bg-zinc-900/30 p-8 backdrop-blur-xl"
     >
-      <div className="mb-5 h-px w-10 bg-green-500 transition-all duration-300 group-hover:w-16" />
-      <h3 className="text-lg font-semibold text-white group-hover:text-green-400 transition-colors">
-        {feature.title}
-      </h3>
-      <p className="mt-2 text-sm font-medium text-zinc-300">{feature.desc}</p>
-      <p className="mt-3 text-sm leading-relaxed text-zinc-500">{feature.detail}</p>
+      <div>
+        <span className="font-mono text-xs uppercase tracking-widest text-zinc-500">
+          {String(index + 1).padStart(2, '0')} / {feature.tag}
+        </span>
+        <h3 className="mt-4 text-xl font-normal text-white">{feature.title}</h3>
+        <p className="mt-2 text-xs text-zinc-400 leading-relaxed">{feature.desc}</p>
+      </div>
+
+      <div className="mt-8 border-t border-zinc-800/60 pt-6">
+        <p className={`text-3xl font-light ${feature.stat.accent ? 'text-emerald-400' : 'text-white'}`}>
+          {feature.stat.value}
+          {feature.stat.unit && <span className="text-sm font-normal text-zinc-400"> {feature.stat.unit}</span>}
+        </p>
+        <p className="mt-1 text-[11px] font-medium tracking-wide uppercase text-zinc-500">{feature.stat.label}</p>
+      </div>
     </motion.div>
   );
 }

--- a/src/components/landing/LandingData.tsx
+++ b/src/components/landing/LandingData.tsx
@@ -1,7 +1,13 @@
 export interface Feature {
+  tag: string;
   title: string;
   desc: string;
-  detail: string;
+  stat: {
+    value: string;
+    unit?: string;
+    label: string;
+    accent?: boolean;
+  };
 }
 
 export interface Step {
@@ -13,34 +19,40 @@ export interface Step {
 
 export const FEATURES: Feature[] = [
   {
+    tag: 'Overview',
     title: 'Listening Stats',
-    desc: 'Your top tracks, artists and genres at a glance.',
-    detail: 'Check out your all time and recent favourites ranked by play count, broken down by track, artist and genre.',
+    desc: 'Top tracks, artists and genres.',
+    stat: { value: '2,847', unit: 'tracks', label: 'Analysed Past 3 Months', accent: true },
   },
   {
+    tag: 'Patterns',
     title: 'Listening Clock',
-    desc: 'A heatmap of when you listen across hours and days.',
-    detail: 'Discover whether you are a night listener, a morning commuter or a weekend binge listener.',
+    desc: 'Your listening habits by hour.',
+    stat: { value: '11 PM', label: 'Peak Listening Hour' },
   },
   {
+    tag: 'Discovery',
     title: 'Discovery Rate',
-    desc: 'See how often you explore new music versus replaying favourites.',
-    detail: 'Track how adventurous your taste is over time and watch your discovery score shift as you branch out or settle in.',
+    desc: 'New music versus replayed favourites.',
+    stat: { value: '27%', label: 'New Artists This Month', accent: true },
   },
   {
+    tag: 'Sessions',
     title: 'Listening Marathons',
     desc: 'Your longest uninterrupted listening sessions.',
-    detail: 'Relive your longest music runs! Every marathon session captured, dated and ranked so you can see when music truly took over.',
+    stat: { value: '5.8', unit: 'hrs', label: 'Longest Session' },
   },
   {
+    tag: 'Phases',
     title: 'Artist Obsessions',
-    desc: 'Phases where one artist took over your life',
-    detail: 'Map the arc of every artist obsession: when it started, how intense it peaked and when you finally moved on.',
+    desc: 'When one artist took over.',
+    stat: { value: '19', unit: 'days', label: 'Longest Obsession', accent: true },
   },
   {
+    tag: 'Charts',
     title: 'Billboard Comparison',
-    desc: 'Measure your taste against the Billboard chart artists.',
-    detail: 'Find out where your listening overlaps with the mainstream.',
+    desc: 'Your taste versus the charts.',
+    stat: { value: '31%', label: 'Mainstream Overlap' },
   },
 ];
 

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -36,18 +36,18 @@ export function LandingPage({ loginUrl }: { loginUrl: string }) {
       </section>
 
       {/* Engineering Capabilities Grid */}
-      <section id="features" className="scroll-mt-20 py-28 px-6">
-        <div className="mx-auto max-w-6xl">
-          <div className="flex flex-col items-start justify-between gap-4 border-b border-zinc-900 pb-8 sm:flex-row sm:items-end">
-            <div>
-              <span className="text-xs font-semibold uppercase tracking-widest text-green-400">Core Features</span>
-              <h2 className="mt-2 text-3xl font-light tracking-tight text-white sm:text-4xl">Data pipeline & metrics</h2>
-            </div>
+      <section id="features" className="scroll-mt-20 py-20 px-4 sm:px-8">
+        <div className="w-full">
+          <div className="mb-12 border-b border-zinc-900 pb-6 text-left">
+            <span className="font-mono text-xs uppercase tracking-widest text-zinc-500">Core Features</span>
+            <h2 className="mt-2 text-4xl font-light tracking-tight text-white sm:text-6xl">
+              Data pipeline and metrics.
+            </h2>
           </div>
 
-          <motion.div variants={containerVariants} initial="hidden" whileInView="visible" viewport={{ once: true, margin: '-80px' }} className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {FEATURES.map((feature) => (
-              <FeatureCard key={feature.title} feature={feature} variants={itemVariants} />
+          <motion.div variants={containerVariants} initial="hidden" whileInView="visible" viewport={{ once: true, margin: '-80px' }} className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map((feature, index) => (
+              <FeatureCard key={feature.title} feature={feature} index={index} variants={itemVariants} />
             ))}
           </motion.div>
         </div>


### PR DESCRIPTION
## Summary

Restyles the Core Features ("Data pipeline and metrics") section so it shares the
same design language as the "Explore your music universe" showcase above it.

- **Cards**: `FeatureCard` now uses the bento tile treatment — `rounded-3xl`
  translucent background with backdrop blur, soft border, mono numbered tag
  (`01 / OVERVIEW`), and the same hover lift as the showcase tiles. The old
  green underline accent and hover color are gone.
- **Stat footers**: each card ends with a showcase-style metric (large light
  number, optional unit, uppercase caption) above a top-rule divider, with
  alternating emerald/white accents.
- **Copy**: descriptions trimmed to one short line per card; the longer detail
  paragraphs were removed.
- **Data**: placeholder stats reframed to a believable 90-day window
  (e.g. "2,847 tracks analysed past 3 months") instead of demo-inflated values.
- **Header**: full-width editorial header (large light heading + bottom rule)
  matching the showcase section.

## Files changed

- `src/components/landing/LandingPage.tsx` — section layout/header
- `src/components/landing/LandingCards.tsx` — FeatureCard restyle
- `src/components/landing/LandingData.tsx` — tags, shortened copy, stat data

## Testing

- `npx tsc -p tsconfig.app.json --noEmit` passes
- Verified visually against the showcase section in the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)