### PR TITLE
feat(frontend): simplified nav and demo video showcase placeholder

### DIFF
--- a/src/components/landing/LandingHero.tsx
+++ b/src/components/landing/LandingHero.tsx
@@ -29,7 +29,7 @@ export function LandingHero({ loginUrl }: { loginUrl: string }) {
   return (
     <section
       ref={heroRef}
-      className="relative flex min-h-[80vh] flex-col items-center justify-center px-4 py-20 text-center"
+      className="relative flex flex-col items-center justify-center px-4 pt-28 pb-20 text-center sm:pt-36"
     >
       {/* Radial Glow */}
       <motion.div

--- a/src/components/landing/LandingNav.tsx
+++ b/src/components/landing/LandingNav.tsx
@@ -18,9 +18,9 @@ export function LandingNav({ loginUrl }: { loginUrl: string }) {
         {/* Far Right: Links + Demo Button */}
         <div className="flex items-center gap-8">
           <div className="hidden gap-8 text-xs font-medium uppercase tracking-widest text-zinc-400 md:flex">
-            <a href="#overview" className="transition-colors hover:text-white">Overview</a>
-            <a href="#features" className="transition-colors hover:text-white">Capabilities</a>
-            <a href="#architecture" className="transition-colors hover:text-white">Architecture</a>
+            <a href="#overview" className="transition-colors hover:text-white">Explore</a>
+            <a href="#features" className="transition-colors hover:text-white">Insights</a>
+            <a href="#architecture" className="transition-colors hover:text-white">How It Works</a>
           </div>
 
           <motion.a 
@@ -29,7 +29,7 @@ export function LandingNav({ loginUrl }: { loginUrl: string }) {
             href={loginUrl} 
             className="rounded-full bg-white px-5 py-2 text-xs font-semibold uppercase tracking-wider text-black transition-colors hover:bg-zinc-200"
           >
-            Demo App
+            Live Demo
           </motion.a>
 
           <button 
@@ -52,9 +52,9 @@ export function LandingNav({ loginUrl }: { loginUrl: string }) {
             exit={{ height: 0, opacity: 0 }} 
             className="overflow-hidden border-t border-zinc-900 bg-zinc-950 px-4 py-4 md:hidden"
           >
-            <a href="#overview" onClick={() => setMenuOpen(false)} className="block py-2 text-xs font-medium uppercase tracking-wider text-zinc-400 hover:text-white">Overview</a>
-            <a href="#features" onClick={() => setMenuOpen(false)} className="block py-2 text-xs font-medium uppercase tracking-wider text-zinc-400 hover:text-white">Capabilities</a>
-            <a href="#architecture" onClick={() => setMenuOpen(false)} className="block py-2 text-xs font-medium uppercase tracking-wider text-zinc-400 hover:text-white">Architecture</a>
+            <a href="#overview" onClick={() => setMenuOpen(false)} className="block py-2 text-xs font-medium uppercase tracking-wider text-zinc-400 hover:text-white">Explore</a>
+            <a href="#features" onClick={() => setMenuOpen(false)} className="block py-2 text-xs font-medium uppercase tracking-wider text-zinc-400 hover:text-white">Insights</a>
+            <a href="#architecture" onClick={() => setMenuOpen(false)} className="block py-2 text-xs font-medium uppercase tracking-wider text-zinc-400 hover:text-white">How It Works</a>
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -6,6 +6,7 @@ import { LandingHero } from './LandingHero';
 import { LandingCta } from './LandingCta';
 import { ShowcaseSection } from './ShowcaseSection';
 import { HeroCollage } from './HeroCollage';
+import { VideoShowcase } from './VideoShowcase';
 
 const containerVariants: Variants = {
   hidden: { opacity: 0 },
@@ -22,6 +23,9 @@ export function LandingPage({ loginUrl }: { loginUrl: string }) {
     <div className="min-h-screen bg-zinc-950 text-zinc-100 selection:bg-green-500 selection:text-black font-sans antialiased">
       <LandingNav loginUrl={loginUrl} />
       <LandingHero loginUrl={loginUrl} />
+
+      {/* Product Demo Video */}
+      <VideoShowcase />
 
       {/* Interactive Feature Highlights */}
       <section id="overview" className="relative w-full px-4 sm:px-8 py-20">

--- a/src/components/landing/VideoShowcase.tsx
+++ b/src/components/landing/VideoShowcase.tsx
@@ -17,7 +17,7 @@ export function VideoShowcase() {
   const glowOpacity = useTransform(scrollYProgress, [0, 0.35], [0, 1]);
 
   return (
-    <section ref={sectionRef} className="relative px-4 pb-20 sm:px-8">
+    <section ref={sectionRef} className="relative px-4 pt-8 pb-4 sm:px-8">
       <motion.div
         style={{ scale }}
         onViewportEnter={() => videoRef.current?.play().catch(() => {})}
@@ -38,7 +38,7 @@ export function VideoShowcase() {
               <span className="h-2.5 w-2.5 rounded-full bg-zinc-700" />
             </div>
             <span className="rounded-full bg-zinc-950/60 px-4 py-1 font-mono text-[11px] tracking-widest text-zinc-500">
-              Live Dashboard Preview
+              Demo
             </span>
           </div>
 

--- a/src/components/landing/VideoShowcase.tsx
+++ b/src/components/landing/VideoShowcase.tsx
@@ -1,0 +1,61 @@
+import { useRef } from 'react';
+import { motion, useScroll, useTransform } from 'framer-motion';
+
+const VIDEO_WEBM = '/demo/soleri-demo.webm';
+const VIDEO_MP4 = '/demo/soleri-demo.mp4';
+const VIDEO_POSTER = '/demo/soleri-demo-poster.jpg';
+
+export function VideoShowcase() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ['start end', 'end start'],
+  });
+  const scale = useTransform(scrollYProgress, [0, 0.35], [0.94, 1]);
+  const glowOpacity = useTransform(scrollYProgress, [0, 0.35], [0, 1]);
+
+  return (
+    <section ref={sectionRef} className="relative px-4 pb-20 sm:px-8">
+      <motion.div
+        style={{ scale }}
+        onViewportEnter={() => videoRef.current?.play().catch(() => {})}
+        onViewportLeave={() => videoRef.current?.pause()}
+        className="relative mx-auto max-w-6xl"
+      >
+        <motion.div
+          style={{ opacity: glowOpacity }}
+          className="pointer-events-none absolute -inset-x-16 -top-16 h-64 rounded-full bg-emerald-500/10 blur-3xl"
+        />
+
+        {/* Browser frame */}
+        <div className="relative overflow-hidden rounded-3xl border border-zinc-800/80 bg-zinc-900/30 shadow-2xl backdrop-blur-xl">
+          <div className="flex items-center gap-4 border-b border-zinc-800/60 px-6 py-4">
+            <div className="flex gap-2">
+              <span className="h-2.5 w-2.5 rounded-full bg-zinc-700" />
+              <span className="h-2.5 w-2.5 rounded-full bg-zinc-700" />
+              <span className="h-2.5 w-2.5 rounded-full bg-zinc-700" />
+            </div>
+            <span className="rounded-full bg-zinc-950/60 px-4 py-1 font-mono text-[11px] tracking-widest text-zinc-500">
+              soleri.app
+            </span>
+          </div>
+
+          <video
+            ref={videoRef}
+            muted
+            loop
+            playsInline
+            preload="none"
+            poster={VIDEO_POSTER}
+            className="aspect-video w-full bg-zinc-950 object-cover"
+          >
+            <source src={VIDEO_WEBM} type="video/webm" />
+            <source src={VIDEO_MP4} type="video/mp4" />
+          </video>
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/src/components/landing/VideoShowcase.tsx
+++ b/src/components/landing/VideoShowcase.tsx
@@ -38,7 +38,7 @@ export function VideoShowcase() {
               <span className="h-2.5 w-2.5 rounded-full bg-zinc-700" />
             </div>
             <span className="rounded-full bg-zinc-950/60 px-4 py-1 font-mono text-[11px] tracking-widest text-zinc-500">
-              soleri.app
+              Live Dashboard Preview
             </span>
           </div>
 


### PR DESCRIPTION
## What is this PR about?

This PR adds a product demo video showcase to the landing page and simplifies
the navigation labels. Visitors currently cannot see the product without
authenticating through Spotify OAuth, so this introduces an ambient demo
recording directly under the hero, giving them an immediate view of what
Soleri does within the first scroll.

## What changed?

**Demo video showcase (`VideoShowcase.tsx`)**
- New section rendered directly beneath the hero, styled as a browser window
  (window dots and a `soleri.app` address pill) to match the site's bento
  design language
- The video is muted, looped and inline, and playback is tied to visibility:
  it plays when scrolled into view and pauses when it leaves, so it has no
  cost once passed
- Scroll-in polish: the frame scales from 94% to 100% with an emerald glow
  fading in, consistent with the hero treatment
- Sources are expected at `public/demo/soleri-demo.webm`, `soleri-demo.mp4`
  and `soleri-demo-poster.jpg`; the section renders a safe empty frame until
  those assets are added

**Navigation (`LandingNav.tsx`)**
- Renamed links to match what each section actually shows:
  Overview → Explore, Capabilities → Insights, Architecture → How It Works
- Renamed the Demo App button to Live Demo, tying it to the CTA section
- Applied to both the desktop bar and the mobile menu; anchors unchanged

## How was this tested?

- `npx tsc -p tsconfig.app.json --noEmit` passes
- Verified in the dev server that the section renders, the frame scales in
  on scroll, and nav anchors still jump to the correct sections

## Notes for reviewers

- The demo recording itself is not included in this PR; the showcase will
  display the poster/empty frame until the assets land in `public/demo/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)