### PR TITLE
feat(frontend): add Terms of Service and Privacy Policy pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useSpotifyAuth } from './hooks';
 import { buildSpotifyAuthUrl } from './api';
 import { LandingPage } from './components/landing';
+import { TermsPage, PrivacyPage } from './components/legal';
 import { Dashboard, ShareModal, QRScannerModal, TasteMatchModal } from './components/dashboard';
 import { encodeTasteProfile } from './lib';
 
@@ -21,6 +22,7 @@ const NAV_ITEMS = [
 ];
 
 export default function App() {
+  const path = window.location.pathname;
   const {
     isLoggedIn,
     topTracks,
@@ -50,6 +52,14 @@ export default function App() {
       genreCounts,
     );
     setTasteMatch({ encodedPayload, theirSpotifyId });
+  }
+
+  if (path === '/terms') {
+    return <TermsPage />;
+  }
+
+  if (path === '/privacy') {
+    return <PrivacyPage />;
   }
 
   if (isLoading) {

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -77,6 +77,8 @@ export function LandingPage({ loginUrl }: { loginUrl: string }) {
           <div className="flex items-center gap-6">
             <a href="https://developer.spotify.com" target="_blank" rel="noopener noreferrer" className="hover:text-zinc-300 transition-colors">Spotify API</a>
             <a href="https://github.com/d4n1elliu/Spoti-list" target="_blank" rel="noopener noreferrer" className="hover:text-zinc-300 transition-colors">Source Code</a>
+            <a href="/terms" className="hover:text-zinc-300 transition-colors">Terms of Service</a>
+            <a href="/privacy" className="hover:text-zinc-300 transition-colors">Privacy Policy</a>
           </div>
           <div>© 2026 Soleri. All Rights Reserved. </div>
         </div>

--- a/src/components/legal/LegalPage.tsx
+++ b/src/components/legal/LegalPage.tsx
@@ -1,0 +1,77 @@
+export interface LegalSection {
+  heading: string;
+  paragraphs: string[];
+}
+
+interface LegalPageProps {
+  title: string;
+  effectiveDate: string;
+  sections: LegalSection[];
+}
+
+export function LegalPage({ title, effectiveDate, sections }: LegalPageProps) {
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100 selection:bg-green-500 selection:text-black font-sans antialiased">
+      {/* Nav */}
+      <nav className="sticky top-0 z-50 border-b border-zinc-900 bg-zinc-950/80 backdrop-blur-xl">
+        <div className="flex w-full items-center justify-between px-4 py-5">
+          <a href="/" className="flex items-center gap-3">
+            <img src="/Soleri.svg" alt="Soleri logo" className="h-7 w-7 rounded-md" />
+            <span className="text-sm font-semibold tracking-wide uppercase text-white">Soleri</span>
+          </a>
+          <a
+            href="/"
+            className="text-xs font-medium uppercase tracking-widest text-zinc-400 transition-colors hover:text-white"
+          >
+            Back to Home
+          </a>
+        </div>
+      </nav>
+
+      {/* Header */}
+      <header className="px-4 pt-20 sm:px-8">
+        <div className="w-full px-4 sm:px-8">
+          <div className="border-b border-zinc-900 pb-6">
+            <span className="font-mono text-xs uppercase tracking-widest text-zinc-500">
+              Effective {effectiveDate}
+            </span>
+            <h1 className="mt-2 text-4xl font-light tracking-tight text-white sm:text-6xl">{title}</h1>
+          </div>
+        </div>
+      </header>
+
+      {/* Body */}
+      <main className="px-4 py-16 sm:px-8">
+        <div className="w-full max-w-3xl px-4 sm:px-8">
+          <div className="flex flex-col gap-12">
+            {sections.map((section, index) => (
+              <section key={section.heading}>
+                <span className="font-mono text-xs uppercase tracking-widest text-zinc-500">
+                  {String(index + 1).padStart(2, '0')} / {section.heading}
+                </span>
+                <div className="mt-4 flex flex-col gap-4">
+                  {section.paragraphs.map((paragraph) => (
+                    <p key={paragraph} className="text-sm leading-relaxed text-zinc-400">
+                      {paragraph}
+                    </p>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-zinc-900 px-8 py-8 text-xs text-zinc-500">
+        <div className="flex w-full flex-col sm:flex-row items-center justify-between gap-4">
+          <div className="flex items-center gap-6">
+            <a href="/terms" className="hover:text-zinc-300 transition-colors">Terms of Service</a>
+            <a href="/privacy" className="hover:text-zinc-300 transition-colors">Privacy Policy</a>
+          </div>
+          <div>© 2026 Soleri. All Rights Reserved.</div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/legal/PrivacyPage.tsx
+++ b/src/components/legal/PrivacyPage.tsx
@@ -1,0 +1,65 @@
+import { LegalPage, type LegalSection } from './LegalPage';
+
+const SECTIONS: LegalSection[] = [
+  {
+    heading: 'Overview',
+    paragraphs: [
+      'This Privacy Policy explains what information Soleri accesses when you connect your Spotify account, how that information is used and the choices you have. Soleri is designed to be privacy friendly: it reads your listening data to show you insights and does not build a profile of you beyond your current session.',
+    ],
+  },
+  {
+    heading: 'Information We Access',
+    paragraphs: [
+      'When you sign in with Spotify, Soleri requests read-only access to your Spotify profile (display name and user ID), your top tracks and artists, your recently played tracks and related metadata such as genres.',
+      'Soleri never receives your Spotify password. Authentication is handled entirely by Spotify through OAuth.',
+    ],
+  },
+  {
+    heading: 'How Your Data Is Used',
+    paragraphs: [
+      'Your listening data is fetched from the Spotify Web API and processed in your browser to calculate the insights shown on your dashboard, such as listening stats, listening patterns, discovery rate and chart comparisons.',
+      'If you use the QR sharing feature, a compact summary of your taste profile is encoded into the QR code you choose to share. Sharing is always initiated by you.',
+    ],
+  },
+  {
+    heading: 'Data Storage and Retention',
+    paragraphs: [
+      'Soleri does not operate a database of user listening history. Authentication tokens are kept in your browser session so you stay signed in, and insights are computed on demand each time you use the dashboard.',
+      'Clearing your browser storage or revoking access in your Spotify settings removes Soleri’s access to your data.',
+    ],
+  },
+  {
+    heading: 'Data Sharing',
+    paragraphs: [
+      'We do not sell, rent or trade your personal information. Your data is not shared with third parties, except the requests made to the Spotify Web API and public chart sources needed to operate the service.',
+    ],
+  },
+  {
+    heading: 'Third Party Services',
+    paragraphs: [
+      'Soleri is built on the Spotify Web API and is hosted on Vercel. Your use of Spotify is governed by Spotify’s own Privacy Policy, and Vercel may collect standard technical logs such as IP addresses as part of hosting the site.',
+    ],
+  },
+  {
+    heading: 'Your Rights and Choices',
+    paragraphs: [
+      'You can disconnect Soleri at any time by revoking its access in your Spotify account settings under Apps. Because Soleri does not retain your listening history, revoking access and clearing your browser storage removes your data from the service.',
+    ],
+  },
+  {
+    heading: 'Changes to This Policy',
+    paragraphs: [
+      'We may update this policy from time to time. Material changes will be reflected by an updated effective date on this page.',
+    ],
+  },
+  {
+    heading: 'Contact',
+    paragraphs: [
+      'If you have questions about this policy or your data, contact us at daniel.liu8750@gmail.com.',
+    ],
+  },
+];
+
+export function PrivacyPage() {
+  return <LegalPage title="Privacy Policy." effectiveDate="August 27, 2026" sections={SECTIONS} />;
+}

--- a/src/components/legal/TermsPage.tsx
+++ b/src/components/legal/TermsPage.tsx
@@ -1,0 +1,70 @@
+import { LegalPage, type LegalSection } from './LegalPage';
+
+const SECTIONS: LegalSection[] = [
+  {
+    heading: 'Acceptance of Terms',
+    paragraphs: [
+      'By accessing or using Soleri, you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the service.',
+    ],
+  },
+  {
+    heading: 'Description of Service',
+    paragraphs: [
+      'Soleri is a music analytics dashboard that connects to your Spotify account and presents insights about your listening habits, including top tracks, artists, genres, listening patterns and comparisons with public chart data.',
+      'Soleri is an independent project and is not affiliated with, endorsed by or sponsored by Spotify AB. Spotify is a trademark of Spotify AB.',
+    ],
+  },
+  {
+    heading: 'Spotify Account Access',
+    paragraphs: [
+      'Soleri uses Spotify OAuth to request read-only access to your account. We never see or store your Spotify password, and Soleri cannot modify your library, playlists or account settings.',
+      'You may revoke Soleri’s access at any time from your Spotify account settings under Apps.',
+    ],
+  },
+  {
+    heading: 'Acceptable Use',
+    paragraphs: [
+      'You agree to use Soleri only for personal, non-commercial purposes and in compliance with applicable laws. You must not attempt to disrupt the service, access other users’ data or use the service to infringe the rights of others.',
+    ],
+  },
+  {
+    heading: 'Intellectual Property',
+    paragraphs: [
+      'The Soleri name, logo and interface are the property of the project author. Music metadata, artwork and related content remain the property of their respective owners, including Spotify and the rights holders it represents.',
+    ],
+  },
+  {
+    heading: 'Third Party Services',
+    paragraphs: [
+      'Soleri relies on third party services, including the Spotify Web API and public chart data. Your use of Spotify through Soleri is also governed by Spotify’s own Terms of Use and Privacy Policy.',
+    ],
+  },
+  {
+    heading: 'Disclaimer of Warranties',
+    paragraphs: [
+      'Soleri is provided as is and as available, without warranties of any kind, express or implied. We do not guarantee that the service will be uninterrupted, accurate or error free.',
+    ],
+  },
+  {
+    heading: 'Limitation of Liability',
+    paragraphs: [
+      'To the maximum extent permitted by law, Soleri and its author shall not be liable for any indirect, incidental or consequential damages arising from your use of the service.',
+    ],
+  },
+  {
+    heading: 'Changes to These Terms',
+    paragraphs: [
+      'We may update these terms from time to time. Material changes will be reflected by an updated effective date on this page. Continued use of the service after changes constitutes acceptance of the revised terms.',
+    ],
+  },
+  {
+    heading: 'Contact',
+    paragraphs: [
+      'If you have questions about these terms, contact us at daniel.liu8750@gmail.com.',
+    ],
+  },
+];
+
+export function TermsPage() {
+  return <LegalPage title="Terms of Service." effectiveDate="August 27, 2026" sections={SECTIONS} />;
+}

--- a/src/components/legal/index.ts
+++ b/src/components/legal/index.ts
@@ -1,0 +1,2 @@
+export { TermsPage } from './TermsPage';
+export { PrivacyPage } from './PrivacyPage';


### PR DESCRIPTION
- Add LegalPage layout with Terms and Privacy content in the landing design language
- Route /terms and /privacy via pathname check in App.tsx (vercel.json already rewrites to index.html)
- Link both pages from the landing footer